### PR TITLE
Improve Hotloading Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 [lib]
 name = "gunship"
 
+[features]
+default = []
+
+timing = []
+hotloading = []
+
 [dependencies.bootstrap_rs]
 version = "*"
 path = "lib/bootstrap_rs"
@@ -19,7 +25,7 @@ path = "lib/bootstrap_audio"
 version = "*"
 path = "lib/parse_collada"
 
-[dependencies.polygon_rs]
+[dependencies.polygon]
 version = "*"
 path = "lib/polygon_rs"
 

--- a/lib/loader/Cargo.toml
+++ b/lib/loader/Cargo.toml
@@ -3,7 +3,7 @@ name = "loader"
 version = "0.0.0"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 
-[[bin]]
+[lib]
 name = "loader"
 
 [dependencies.bootstrap_rs]

--- a/lib/loader/src/loader.rs
+++ b/lib/loader/src/loader.rs
@@ -1,4 +1,4 @@
-#![feature(std_misc)]
+#![feature(dynamic_lib)]
 
 extern crate bootstrap_rs as bootstrap;
 extern crate winapi;
@@ -26,15 +26,13 @@ type EngineDrop = fn(Box<()>);
 type GameInit = fn(&mut ());
 type GameReload = fn(&(), &());
 
-const SRC_LIB: &'static str = "target/debug/hotload.dll";
-
-fn update_dll(dest: &str, last_modified: &mut u64) -> bool {
-    let modified = match file_modified(SRC_LIB) {
+fn update_dll(src_lib: &str, dest: &str, last_modified: &mut u64) -> bool {
+    let modified = match file_modified(src_lib) {
         Ok(modified) => modified,
         Err(_) => return false,
     };
     if modified > *last_modified {
-        println!("copy result: {:?}", fs::copy(SRC_LIB, dest));
+        println!("copy result: {:?}", fs::copy(src_lib, dest));
         *last_modified = modified;
         true
     } else {
@@ -66,21 +64,21 @@ fn load_engine_procs(lib: &DynamicLibrary) -> (EngineUpdateAndRender, EngineClos
 /// - Keep track of the temp files made and then delete them when done running.
 /// - Support reloading game code.
 /// - Reload the windows message proc when the engine is reloaded.
-fn main() {
+pub fn run_loader(src_lib: &str) {
     let mut counter = 0..;
 
     // Statically create a window and load the renderer for the engine.
     let instance = bootstrap::init();
     let window = Window::new("Gunship Game", instance);
-    bootstrap::windows::gl::set_proc_loader();
     let mut temp_paths: Vec<String> = Vec::new();
+
 
     // Open the game as a dynamic library.
     let mut last_modified = 0;
     let (mut _lib, mut engine, mut engine_update_and_render, mut engine_close, mut engine_drop) = {
         let lib_path = format!("gunship_lib_{}.dll", counter.next().unwrap().to_string());
-        if !update_dll(&lib_path, &mut last_modified) {
-            panic!("Unable to find library {} for dynamic loading", SRC_LIB);
+        if !update_dll(src_lib, &lib_path, &mut last_modified) {
+            panic!("Unable to find library {} for dynamic loading", src_lib);
         }
         let lib = match DynamicLibrary::open(Some(Path::new(&lib_path))) {
             Ok(lib) => lib,
@@ -112,7 +110,7 @@ fn main() {
 
         // Only reload if file has changed.
         let lib_path = format!("gunship_lib_{}.dll", counter.next().unwrap());
-        if update_dll(&lib_path, &mut last_modified) {
+        if update_dll(src_lib, &lib_path, &mut last_modified) {
             if let Ok(lib) = DynamicLibrary::open(Some(Path::new(&lib_path))) {
 
                 let engine_reload = unsafe {

--- a/lib/polygon_rs/Cargo.toml
+++ b/lib/polygon_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "polygon_rs"
+name = "polygon"
 version = "0.0.1"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 

--- a/lib/stopwatch/src/lib.rs
+++ b/lib/stopwatch/src/lib.rs
@@ -8,6 +8,8 @@ use std::io::Write;
 
 use bootstrap::time::Timer;
 
+pub mod null;
+
 /// A global access point for collecting logs. This allows client code to create stopwatches
 /// anywhere without having to pass the Collector around.
 static mut COLLECTOR: *mut Collector = 0 as *mut Collector;

--- a/lib/stopwatch/src/null.rs
+++ b/lib/stopwatch/src/null.rs
@@ -1,0 +1,36 @@
+pub struct Collector;
+
+impl Collector {
+    pub fn new() -> Result<Box<Collector>, ()> {
+        Ok(Box::new(Collector))
+    }
+
+    pub fn flush_to_file(&mut self, _file_name: &str) {
+    }
+}
+
+impl Drop for Collector {
+    /// Doesn't do anything, but ensure that anything that has a Collector as a member still
+    /// requires drop in case that has any implications for compilation.
+    fn drop(&mut self) {
+    }
+}
+
+pub struct Stopwatch;
+
+impl Stopwatch {
+    pub fn new() -> Stopwatch {
+        Stopwatch
+    }
+
+    pub fn named(_name: &str) -> Stopwatch {
+        Stopwatch
+    }
+}
+
+impl Drop for Stopwatch {
+    /// Doesn't do anything, but ensure that anything that has a Collector as a member still
+    /// requires drop in case that has any implications for compilation.
+    fn drop(&mut self) {
+    }
+}

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -44,7 +44,7 @@ pub trait System {
     fn update(&mut self, scene: &Scene, delta: f32);
 }
 
-pub trait ComponentManager {
+pub trait ComponentManager: ::std::any::Any {
     /// Destroy all component data associated with the entity.
     fn destroy_all(&self, Entity);
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -19,7 +19,11 @@ use bs_audio;
 
 use polygon::gl_render::GLRender;
 
+#[cfg(feature = "timing")]
 use self::stopwatch::{Collector, Stopwatch};
+
+#[cfg(not(feature = "timing"))]
+use self::stopwatch::null::{Collector, Stopwatch};
 
 use scene::Scene;
 use resource::ResourceManager;

--- a/src/gunship.rs
+++ b/src/gunship.rs
@@ -3,7 +3,7 @@
 extern crate bootstrap_rs as bootstrap;
 extern crate bootstrap_audio as bs_audio;
 extern crate parse_collada as collada;
-extern crate polygon_rs as polygon;
+extern crate polygon;
 extern crate polygon_math as math;
 
 pub mod engine;


### PR DESCRIPTION
- Changes hotloader to be a lib rather than a bin so that client
libraries can list it as a dependency and compile it automatically.
- Removes the hard-coded path to the game dll from loader in favor of
having the client lib pass it in when starting the loader.
- renames polygon_rs crate to polygon in order to avoid breakage with
hotloading. It probably should just be polygon, anyway, so not a big
deal.
- Adds a null module to the stopwatch crate so that client code can
disable usage of stopwatch without removing all calls to its code.
- Adds "timing" and "hotloading" features to gunship to allow client
code to enable and disable timing critical sections and hotloading
respectively.
- Fixes hotloading by using a modified version of the type name when the
hotloading feature is enabled. When hotloading is disabled the TypeId is
used instead because it is cheaper at runtime.