### PR TITLE
COLLADA Parsing Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ stopwatch       = { path = "lib/stopwatch" }
 [dev_dependencies]
 rand = "*"
 
-[profile.dev]
-opt-level = 1
+# [profile.dev]
+# opt-level = 1
 
 [profile.release]
 # lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gunship"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 
 [lib]

--- a/lib/bootstrap_audio/src/windows.rs
+++ b/lib/bootstrap_audio/src/windows.rs
@@ -6,7 +6,7 @@ use std::mem;
 
 use self::winapi::*;
 
-#[derive(Debug)] #[allow(raw_pointer_derive)]
+#[derive(Debug)]
 pub struct AudioSource {
     audio_client: *mut IAudioClient,
     render_client: *mut IAudioRenderClient,

--- a/lib/bootstrap_rs/src/linux/window.rs
+++ b/lib/bootstrap_rs/src/linux/window.rs
@@ -12,7 +12,6 @@ use window::Message;
 use input::ScanCode;
 
 #[derive(Debug, Clone)]
-#[allow(raw_pointer_derive)]
 pub struct Window {
     pub display: *mut xlib::Display,
     pub window: xlib::Window,

--- a/lib/parse_collada/Cargo.toml
+++ b/lib/parse_collada/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "parse_collada"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 
 [dependencies.parse_xml]

--- a/lib/parse_collada/src/lib.rs
+++ b/lib/parse_collada/src/lib.rs
@@ -519,8 +519,15 @@ pub struct InstanceCamera;
 #[derive(Debug, Clone)]
 pub struct InstanceController;
 
-#[derive(Debug, Clone)]
-pub struct InstanceEffect;
+collada_element!("instance_effect", InstanceEffect => {
+    req attrib url: String
+    opt attrib sid: String,
+    opt attrib name: String
+
+    rep child technique_hint: TechniqueHint,
+    rep child setparam: SetParam,
+    rep child extra: Extra
+});
 
 #[derive(Debug, Clone)]
 pub struct InstanceGeometry {
@@ -573,8 +580,15 @@ pub struct LibraryImages;
 #[derive(Debug, Clone)]
 pub struct LibraryLights;
 
-#[derive(Debug, Clone)]
-pub struct LibraryMaterials;
+collada_element!("library_materials", LibraryMaterials => {
+    opt attrib id: String,
+    opt attrib name: String
+
+    opt child asset: Asset
+
+    rep child material: Material,
+    rep child extra: Extra
+});
 
 #[derive(Debug, Clone)]
 pub struct LibraryNodes;
@@ -600,6 +614,15 @@ collada_element!("library_visual_scenes", LibraryVisualScenes => {
 
 #[derive(Debug, Clone)]
 pub struct LookAt;
+
+collada_element!("material", Material => {
+    opt attrib id: String,
+    opt attrib name: String
+
+    req child instance_effect: InstanceEffect
+    opt child asset: Asset
+    rep child extra: Extra
+});
 
 #[derive(Debug, Clone)]
 pub struct Matrix {
@@ -727,15 +750,15 @@ impl ColladaElement for Node {
                     node.transformations.push(TransformationElement::Matrix(matrix));
                 },
                 StartElement("rotate") => {
-                    let rotate = try!(parser.parse_rotate());
+                    let rotate = try!(parse_element(parser, "node"));
                     node.transformations.push(TransformationElement::Rotate(rotate));
                 },
                 StartElement("scale") => {
-                    let scale = try!(parser.parse_scale());
+                    let scale = try!(parse_element(parser, "node"));
                     node.transformations.push(TransformationElement::Scale(scale));
                 },
                 StartElement("skew") => {
-                    let skew = try!(parser.parse_skew());
+                    let skew = try!(parse_element(parser, "node"));
                     node.transformations.push(TransformationElement::Skew(skew));
                 },
                 StartElement("translate") => {
@@ -861,17 +884,11 @@ collada_element!("render", Render => {
     rep child extra: Extra
 });
 
-#[derive(Debug, Clone)]
-pub struct Rotate;
-
-#[derive(Debug, Clone)]
-pub struct Scale;
-
-#[derive(Debug, Clone)]
-pub struct Scene;
-
-#[derive(Debug, Clone)]
-pub struct Skew;
+collada_element!("rotate", Rotate => {});
+collada_element!("scale", Scale => {});
+collada_element!("scene", Scene => {});
+collada_element!("setparam", SetParam => {});
+collada_element!("skew", Skew => {});
 
 #[derive(Debug, Clone)]
 pub struct Source {
@@ -938,6 +955,8 @@ impl ColladaElement for Technique {
         .map_err(|err| Error::XmlError(err))
     }
 }
+
+collada_element!("technique_hint", TechniqueHint => {});
 
 #[derive(Debug, Clone)]
 pub enum TransformationElement {
@@ -1130,7 +1149,9 @@ impl<'a> ColladaParser<'a> {
                 },
                 StartElement("library_images") => self.parse_library_images(),
                 StartElement("library_lights") => self.parse_library_lights(),
-                StartElement("library_materials") => self.parse_library_materials(),
+                StartElement("library_materials") => {
+                    collada.library_materials = Some(try!(parse_element(self, "COLLADA")));
+                },
                 StartElement("library_nodes") => self.parse_library_nodes(),
                 StartElement("library_physics_materials") => self.parse_library_physics_materials(),
                 StartElement("library_physics_models") => self.parse_library_physics_models(),
@@ -1401,12 +1422,6 @@ impl<'a> ColladaParser<'a> {
         self.skip_to_end_element("library_lights");
     }
 
-    fn parse_library_materials(&mut self) {
-        println!("Skipping over <library_materials> element");
-        println!("Warning: <library_materials> is not yet supported by parse_collada");
-        self.skip_to_end_element("library_materials");
-    }
-
     fn parse_library_nodes(&mut self) {
         println!("Skipping over <library_nodes> element");
         println!("Warning: <library_nodes> is not yet supported by parse_collada");
@@ -1532,34 +1547,10 @@ impl<'a> ColladaParser<'a> {
         self.skip_to_end_element("polylist");
     }
 
-    fn parse_rotate(&mut self) -> Result<Rotate> {
-        println!("Skipping over <rotate> element");
-        println!("Warning: <rotate> is not yet supported by parse_collada");
-        self.skip_to_end_element("rotate");
-
-        Ok(Rotate)
-    }
-
-    fn parse_scale(&mut self) -> Result<Scale> {
-        println!("Skipping over <scale> element");
-        println!("Warning: <scale> is not yet supported by parse_collada");
-        self.skip_to_end_element("scale");
-
-        Ok(Scale)
-    }
-
     fn parse_scene(&mut self) {
         println!("Skipping over <scene> element");
         println!("Warning: <scene> is not yet supported by parse_collada");
         self.skip_to_end_element("scene");
-    }
-
-    fn parse_skew(&mut self) -> Result<Skew> {
-        println!("Skipping over <skew> element");
-        println!("Warning: <skew> is not yet supported by parse_collada");
-        self.skip_to_end_element("skew");
-
-        Ok(Skew)
     }
 
     fn parse_spline(&mut self) {

--- a/lib/parse_collada/src/lib.rs
+++ b/lib/parse_collada/src/lib.rs
@@ -929,14 +929,13 @@ impl ColladaElement for Source {
 }
 
 #[derive(Debug, Clone)]
-pub struct Technique;
+pub struct Technique(xml::dom::Node);
 
 impl ColladaElement for Technique {
     fn parse(parser: &mut ColladaParser, _: &str) -> Result<Technique> {
-        println!("Skipping over <technique>");
-        println!("<technique> is not yet supported by parse-collada");
-        parser.skip_to_end_element("technique");
-        Ok(Technique)
+        xml::dom::Node::from_events(&mut parser.events, "technique")
+        .map(|node| Technique(node))
+        .map_err(|err| Error::XmlError(err))
     }
 }
 
@@ -1667,7 +1666,7 @@ impl<'a> ColladaParser<'a> {
     /// panicking if there is no next event.
     fn next_event(&mut self) -> xml::Event<'a> {
         match self.events.next() {
-            None => panic!("Ran out of events too early."),
+            None => panic!("Ran out of events too early."), // TODO: Don't panic!
             Some(event) => event
         }
     }

--- a/lib/parse_collada/src/lib.rs
+++ b/lib/parse_collada/src/lib.rs
@@ -257,47 +257,6 @@ fn parse_element<T: ColladaElement>(parser: &mut ColladaParser, parent: &str) ->
     T::parse(parser, parent)
 }
 
-// impl ColladaElement for T {
-//     fn parse(parser: &mut ColladaParser, parent: &str) -> Result<T> {
-//         let text = try!(parser.parse_text_node(parent));
-//         T::from_str(text).map_err(|_| {
-//             Error::ParseError(String::from(text))
-//         })
-//     }
-// }
-
-impl ColladaElement for String {
-    fn parse(parser: &mut ColladaParser, parent: &str) -> Result<String> {
-        let text = {
-            let event = parser.next_event();
-            match event {
-                TextNode(text) => text,
-                EndElement(_) => {
-                    return Ok(String::from(""));
-                },
-                _ => return Err(illegal_event(event, parent)),
-            }
-        };
-
-        let event = parser.next_event();
-        match event {
-            EndElement(_) => {},
-            _ => return Err(illegal_event(event, parent)),
-        }
-
-        Ok(String::from(text))
-    }
-}
-
-impl ColladaElement for f32 {
-    fn parse(parser: &mut ColladaParser, parent: &str) -> Result<f32> {
-        let text = try!(parser.parse_text_node(parent));
-        f32::from_str(text).map_err(|_| {
-            Error::ParseError(String::from(text))
-        })
-    }
-}
-
 pub trait ColladaAttribute: Sized {
     fn parse(text: &str) -> Result<Self>;
 }
@@ -443,19 +402,35 @@ pub enum ArrayElement {
 }
 
 collada_element!("asset", Asset => {
-    req child created: String,
-    req child modified: String
+    req child created: Created,
+    req child modified: Modified
 
     opt child coverage: Coverage,
-    opt child keywords: String,
-    opt child revision: String,
-    opt child subject: String,
-    opt child title: String,
+    opt child keywords: Keywords,
+    opt child revision: Revision,
+    opt child subject: Subject,
+    opt child title: Title,
     opt child unit: Unit,
     opt child up_axis: UpAxis
 
     rep child contributor: Contributor,
     rep child extra: Extra
+});
+
+collada_element!("author", Author => {
+    contents: String
+});
+
+collada_element!("author_email", AuthorEmail => {
+    contents: String
+});
+
+collada_element!("author_website", AuthorWebsite => {
+    contents: String
+});
+
+collada_element!("authoring_tool", AuthoringTool => {
+    contents: String
 });
 
 collada_element!("bind", Bind => {});
@@ -478,20 +453,32 @@ collada_element!("color", Color => {
     contents: Vec<f32>
 });
 
+collada_element!("comments", Comments => {
+    contents: String
+});
+
 collada_element!("contributor", Contributor => {
-    opt child author:         String,
-    opt child author_email:   String,
-    opt child author_website: String,
-    opt child authoring_tool: String,
-    opt child comments:       String,
-    opt child copyright:      String,
-    opt child source_data:    String
+    opt child author:         Author,
+    opt child author_email:   AuthorEmail,
+    opt child author_website: AuthorWebsite,
+    opt child authoring_tool: AuthoringTool,
+    opt child comments:       Comments,
+    opt child copyright:      Copyright,
+    opt child source_data:    SourceData
 });
 
 collada_element!("constant", ConstantFx => {});
 
+collada_element!("copyright", Copyright => {
+    contents: String
+});
+
 collada_element!("coverage", Coverage => {
     opt child geographic_location: GeographicLocation
+});
+
+collada_element!("created", Created => {
+    contents: String
 });
 
 collada_element!("diffuse", Diffuse => {
@@ -725,8 +712,8 @@ impl ColladaElement for Geometry {
 }
 
 collada_element!("geographic_location", GeographicLocation => {
-    req child longitude: f32,
-    req child latitude: f32,
+    req child longitude: Longitude,
+    req child latitude: Latitude,
     req child altitude: Altitude
 });
 
@@ -806,6 +793,10 @@ collada_element!("instance_visual_scene", InstanceVisualScene => {
 
 collada_element!("int_array", IntArray => {});
 
+collada_element!("keywords", Keywords => {
+    contents: String
+});
+
 collada_element!("lambert", Lambert => {
     opt child emission: Emission,
     opt child ambient: AmbientFx,
@@ -814,6 +805,14 @@ collada_element!("lambert", Lambert => {
     opt child transparent: Transparent,
     opt child transparency: Transparency,
     opt child index_of_refraction: IndexOfRefraction
+});
+
+collada_element!("latitude", Latitude => {
+    contents: f32
+});
+
+collada_element!("layer", Layer => {
+    contents: String
 });
 
 collada_element!("library_animations", LibraryAnimations => {
@@ -894,6 +893,10 @@ collada_element!("library_visual_scenes", LibraryVisualScenes => {
     rep child extra: Extra
 });
 
+collada_element!("longitude", Longitude => {
+    contents: f32
+});
+
 #[derive(Debug, Clone)]
 pub struct LookAt;
 
@@ -961,6 +964,10 @@ impl ColladaElement for Mesh {
         Ok(mesh)
     }
 }
+
+collada_element!("modified", Modified => {
+    contents: String
+});
 
 collada_element!("Name_array", NameArray => {});
 collada_element!("newparam", NewParam => {});
@@ -1231,8 +1238,12 @@ collada_element!("render", Render => {
 
     opt child instance_material: InstanceMaterial
 
-    rep child layer: String,
+    rep child layer: Layer,
     rep child extra: Extra
+});
+
+collada_element!("revision", Revision => {
+    contents: String
 });
 
 collada_element!("rotate", Rotate => {});
@@ -1276,6 +1287,14 @@ collada_element!("source", Source => {
         "SIDREF_array" => Sidref(SidrefArray),
         "token_array" => Token(TokenArray)
     }
+});
+
+collada_element!("source_data", SourceData => {
+    contents: String
+});
+
+collada_element!("subject", Subject => {
+    contents: String
 });
 
 #[derive(Debug, Clone)]
@@ -1333,6 +1352,11 @@ collada_element!("technique", TechniqueFxCommon => {
 
 collada_element!("technique_hint", TechniqueHint => {});
 collada_element!("texture", Texture => {});
+
+collada_element!("title", Title => {
+    contents: String
+});
+
 collada_element!("token_array", TokenArray => {});
 
 #[derive(Debug, Clone)]

--- a/lib/parse_xml/Cargo.toml
+++ b/lib/parse_xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parse_xml"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 
 [dependencies]

--- a/lib/parse_xml/src/dom.rs
+++ b/lib/parse_xml/src/dom.rs
@@ -1,6 +1,6 @@
 use super::{Event, EventIterator, Result};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Node {
     pub name: String,
     pub attributes: Vec<Attribute>,
@@ -42,7 +42,7 @@ impl Node {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Attribute {
     pub name: String,
     pub value: String,

--- a/lib/parse_xml/src/dom.rs
+++ b/lib/parse_xml/src/dom.rs
@@ -1,0 +1,49 @@
+use super::{Event, EventIterator, Result};
+
+#[derive(Debug, Clone)]
+pub struct Node {
+    pub name: String,
+    pub attributes: Vec<Attribute>,
+    pub children: Vec<Node>,
+    pub contents: Vec<String>,
+}
+
+impl Node {
+    pub fn from_events(events: &mut EventIterator, root: &str) -> Result<Node> {
+        let mut node = Node {
+            name: String::from(root),
+            attributes: Vec::new(),
+            children: Vec::new(),
+            contents: Vec::new(),
+        };
+
+        loop {
+            let event = events.next().unwrap(); // TODO: Don't panic!
+            match event {
+                Event::Attribute(name_str, value_str) => {
+                    node.attributes.push(Attribute {
+                        name: String::from(name_str),
+                        value: String::from(value_str),
+                    });
+                },
+                Event::StartElement(name_str) => {
+                    let child = try!(Node::from_events(events, name_str));
+                    node.children.push(child);
+                },
+                Event::TextNode(contents_str) => {
+                    node.contents.push(String::from(contents_str));
+                },
+                Event::EndElement(element) if element == root => break,
+                _ => return Err(format!("Illegal event while parsing dom: {:?}", event)),
+            }
+        }
+
+        Ok(node)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Attribute {
+    pub name: String,
+    pub value: String,
+}

--- a/lib/parse_xml/src/test/mod.rs
+++ b/lib/parse_xml/src/test/mod.rs
@@ -94,7 +94,7 @@ fn test_declaration() {
 
 #[test]
 fn test_file() {
-    let file = load_file( "../../meshes/cube.dae" );
+    let file = load_file( "../../meshes/cube.dae" ); // TODO: Don't even bother loading the file, just copy it into here as a raw string.
 
     parse!(XML file, {
         Declaration("1.0", "utf-8");

--- a/src/component/collider/grid_collision.rs
+++ b/src/component/collider/grid_collision.rs
@@ -295,7 +295,6 @@ impl Clone for GridCollisionSystem {
 }
 
 #[derive(Debug)]
-#[allow(raw_pointer_derive)]
 struct WorkUnit {
     collisions: HashMap<(Entity, Entity), (), FnvHashState>, // This should be a HashSet, but HashSet doesn't have a way to get at entries directly.
     bounds: AABB,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::intrinsics;
 use std::raw::TraitObject;
 use std::mem;
+use std::time::Duration;
 
 use bootstrap;
 use bootstrap::input::ScanCode;
@@ -228,7 +229,7 @@ impl Engine {
             // Wait for target frame time.
             let mut remaining_time_ms = TARGET_FRAME_TIME_MS - timer.elapsed_ms(start_time);
             while remaining_time_ms > 1.0 {
-                thread::sleep_ms(remaining_time_ms as u32);
+                thread::sleep(Duration::from_millis(remaining_time_ms as u64));
                 remaining_time_ms = TARGET_FRAME_TIME_MS - timer.elapsed_ms(start_time);
             }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -6,7 +6,7 @@ use std::error::Error;
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use collada::{self, COLLADA, GeometricElement, ArrayElement, PrimitiveType, VisualScene, Geometry,
+use collada::{self, Collada, GeometricElement, ArrayElement, PrimitiveType, VisualScene, Geometry,
               Node};
 
 use polygon::gl_render::{GLRender, GLMeshData, ShaderProgram};
@@ -64,9 +64,9 @@ impl ResourceManager {
                 "{} could not be loaded because it is not a file",
                 full_path.display()));
         }
-        let collada_data = match COLLADA::load(&full_path) {
+        let collada_data = match Collada::load(&full_path) {
             Err(why) => return Err(format!(
-                "couldn't open {}: {}",
+                "couldn't open {}: {:?}",
                 full_path.display(),
                 &why)),
             Ok(data) => data,

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -47,8 +47,6 @@ impl ResourceManager {
 
     /// TODO: Perform validity checking on data when loading (e.g. make sure all nodes have an id).
     pub fn load_model<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
-        println!("load_model({:?})", path.as_ref());
-
         let mut visual_scenes = self.visual_scenes.borrow_mut();
         let mut geometries = self.geometries.borrow_mut();
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -47,6 +47,8 @@ impl ResourceManager {
 
     /// TODO: Perform validity checking on data when loading (e.g. make sure all nodes have an id).
     pub fn load_model<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
+        println!("load_model({:?})", path.as_ref());
+
         let mut visual_scenes = self.visual_scenes.borrow_mut();
         let mut geometries = self.geometries.borrow_mut();
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -401,7 +401,7 @@ fn geometry_to_mesh(geometry: &Geometry) -> Mesh {
 fn get_raw_positions(mesh: &collada::Mesh) -> &[f32] {
     // TODO: Consult the correct element (<triangles> for now) to determine which source has position data.
     let position_data: &[f32] = match *mesh.source[0].array_element.as_ref().unwrap() {
-        ArrayElement::Float(ref float_array) => float_array.as_ref(),
+        ArrayElement::Float(ref float_array) => float_array.contents.as_ref(),
         _ => panic!("Only float arrays supported for vertex position array"),
     };
     assert!(position_data.len() > 0);
@@ -412,7 +412,7 @@ fn get_raw_positions(mesh: &collada::Mesh) -> &[f32] {
 fn get_normals(mesh: &collada::Mesh) -> &[f32] {
     // TODO: Consult the correct element (<triangles> for now) to determine which source has normal data.
     let normal_data: &[f32] = match *mesh.source[1].array_element.as_ref().unwrap() {
-        ArrayElement::Float(ref float_array) => float_array.as_ref(),
+        ArrayElement::Float(ref float_array) => float_array.contents.as_ref(),
         _ => panic!("Only float arrays supported for vertex normal array")
     };
     assert!(normal_data.len() > 0);

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -335,7 +335,7 @@ impl ResourceManager {
 /// In order to to this, it reorganizes the normals, UVs, and other vertex attributes to
 /// be in the same order as the vertex positions.
 fn geometry_to_mesh(geometry: &Geometry) -> Mesh {
-    let mesh = match geometry.data {
+    let mesh = match geometry.geometric_element {
         GeometricElement::Mesh(ref mesh) => mesh,
         _ => panic!("No mesh found within geometry")
     };


### PR DESCRIPTION
- Updates the compiler to the latest nightly.
- Changes parse-collada to use a super cool new macro that generates the parsing code based on a definition of each element's structure.
- Implements COLLADA parsing for the elements that were previously spitting out warnings in the current game.

This PR marks the start of the policy that merging a branch into master means bumping the version number of any updated libraries.