### PR TITLE
Improved Mesh Compilation 

### DIFF
--- a/.clog.toml
+++ b/.clog.toml
@@ -1,0 +1,6 @@
+[clog]
+repository = "https://github.com/excaliburHisSheath/gunship-rs"
+outfile = "CHANGELOG.md"
+
+[sections]
+"Features" = ["feature", "feat"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+<a name="v0.0.3"></a>
+### v0.0.3 (2015-12-07)
+
+
+#### Breaking Changes
+
+* **parse-collada:**  rename PrimitiveType to PrimitiveElements ([f1cd6b4a](https://github.com/excaliburHisSheath/gunship-rs/commit/f1cd6b4af8b78ce2055da7e7e81f793fdc8c1306), breaks [#](https://github.com/excaliburHisSheath/gunship-rs/issues/))
+* **polygon::MeshBuilder:** remove `Mesh::from_raw_data()` and replace it's functionality with `MeshBuilder`. ([907bf23c](https://github.com/excaliburHisSheath/gunship-rs/commit/907bf23cb8fca9c87c8d8aeff69a2646212ac8be))
+
+#### Features
+
+* **parse-collada:**
+  *  add implementation for primitive elements ([953ac4bd](https://github.com/excaliburHisSheath/gunship-rs/commit/953ac4bdc5583fbf0551e799d1f6f947dc792ecf))
+  *  better support parsing normal data ([6edf9162](https://github.com/excaliburHisSheath/gunship-rs/commit/6edf916283452a8d0f39a692e4810eb03dd66df2))
+* **polygon-math::Vector2:**
+  *  add Vector2::as_ref() ([d7eda56c](https://github.com/excaliburHisSheath/gunship-rs/commit/d7eda56c15fa560e081f2138d8c3b576e26e43ff))
+  *  add Vector2 type and other utilities ([137f3c36](https://github.com/excaliburHisSheath/gunship-rs/commit/137f3c36299edb5b62ab8bd053e09d786a9c22ea))
+* **polygon::MeshBuilder:**
+  *  support texcoord vertex attributes ([03e875c7](https://github.com/excaliburHisSheath/gunship-rs/commit/03e875c74425becfe4bef95759d33a0a35e2fda0))
+  *  add mesh builder system ([907bf23c](https://github.com/excaliburHisSheath/gunship-rs/commit/907bf23cb8fca9c87c8d8aeff69a2646212ac8be))
+* **resource::collada:**
+  *  process texcoord vertex data ([a87e2c96](https://github.com/excaliburHisSheath/gunship-rs/commit/a87e2c962d2de2f23162e061295603f36e25a365))
+  *  more robust collada mesh processing ([bb075efa](https://github.com/excaliburHisSheath/gunship-rs/commit/bb075efa155132d8a864fa0f1042a8714a744dcd))
+
+#### Bug Fixes
+
+* **parse-collada:**  rename PrimitiveType to PrimitiveElements ([f1cd6b4a](https://github.com/excaliburHisSheath/gunship-rs/commit/f1cd6b4af8b78ce2055da7e7e81f793fdc8c1306), breaks [#](https://github.com/excaliburHisSheath/gunship-rs/issues/))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "gunship"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 
 [lib]

--- a/lib/parse_collada/Cargo.toml
+++ b/lib/parse_collada/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "parse_collada"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 
 [dependencies.parse_xml]

--- a/lib/parse_collada/src/lib.rs
+++ b/lib/parse_collada/src/lib.rs
@@ -1084,8 +1084,25 @@ collada_element!("library_visual_scenes", LibraryVisualScenes => {
     rep child extra: Extra
 });
 
-collada_element!("lines", Lines => {});
-collada_element!("linestrips", Linestrips => {});
+collada_element!("lines", Lines => {
+    req attrib count: usize
+    opt attrib name: String,
+    opt attrib material: String
+
+    opt child p: Primitive
+    rep child input: InputShared,
+    rep child extra: Extra
+});
+
+collada_element!("linestrips", Linestrips => {
+    req attrib count: usize
+    opt attrib name: String,
+    opt attrib material: String
+
+    rep child input: InputShared,
+    rep child p: Primitive,
+    rep child extra: Extra
+});
 
 collada_element!("longitude", Longitude => {
     contents: f32
@@ -1356,9 +1373,35 @@ impl ColladaElement for Param {
 }
 
 collada_element!("param", ParamReference => {});
+
+collada_element!("ph", PrimitiveHoles => {
+    req child p: Primitive
+    rep child h: Primitive
+});
+
 collada_element!("phong", Phong => {});
-collada_element!("polygons", Polygons => {});
-collada_element!("polylist", Polylist => {});
+
+collada_element!("polygons", Polygons => {
+    req attrib count: usize
+    opt attrib material: String,
+    opt attrib name: String
+
+    rep child input: InputShared,
+    rep child p: Primitive,
+    rep child ph: PrimitiveHoles,
+    rep child extra: Extra
+});
+
+collada_element!("polylist", Polylist => {
+    req attrib count: usize
+    opt attrib name: String,
+    opt attrib material: String
+
+    opt child vcount: VCount,
+    opt child p: Primitive
+    rep child input: InputShared,
+    rep child extra: Extra
+});
 
 collada_element!("p", Primitive => {
     contents: Vec<usize>
@@ -1373,6 +1416,36 @@ pub enum PrimitiveElements {
     Triangles(Triangles),
     Trifans(Trifans),
     Tristrips(Tristrips)
+}
+
+impl PrimitiveElements {
+    /// Retrieve the element's list of inputs regardless of the specific variant.
+    ///
+    /// All primitive elements have a list of <input> (shared) elements, so this utility method
+    /// retrieves the `&[InputShared]` from the primitive element regardless of the variant.
+    pub fn input(&self) -> &[InputShared] {
+        match *self {
+            PrimitiveElements::Lines(ref element)      => &*element.input,
+            PrimitiveElements::Linestrips(ref element) => &*element.input,
+            PrimitiveElements::Polygons(ref element)   => &*element.input,
+            PrimitiveElements::Polylist(ref element)   => &*element.input,
+            PrimitiveElements::Triangles(ref element)  => &*element.input,
+            PrimitiveElements::Trifans(ref element)    => &*element.input,
+            PrimitiveElements::Tristrips(ref element)  => &*element.input,
+        }
+    }
+
+    pub fn count(&self) -> usize {
+        match *self {
+            PrimitiveElements::Lines(ref element)      => element.count,
+            PrimitiveElements::Linestrips(ref element) => element.count,
+            PrimitiveElements::Polygons(ref element)   => element.count,
+            PrimitiveElements::Polylist(ref element)   => element.count,
+            PrimitiveElements::Triangles(ref element)  => element.count,
+            PrimitiveElements::Trifans(ref element)    => element.count,
+            PrimitiveElements::Tristrips(ref element)  => element.count,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1635,8 +1708,25 @@ collada_element!("triangles", Triangles => {
     rep child extra: Extra
 });
 
-collada_element!("trifans", Trifans => {});
-collada_element!("tristrips", Tristrips => {});
+collada_element!("trifans", Trifans => {
+    req attrib count: usize
+    opt attrib name: String,
+    opt attrib material: String
+
+    rep child input: InputShared,
+    rep child p: Primitive,
+    rep child extra: Extra
+});
+
+collada_element!("tristrips", Tristrips => {
+    req attrib count: usize
+    opt attrib name: String,
+    opt attrib material: String
+
+    rep child input: InputShared,
+    rep child p: Primitive,
+    rep child extra: Extra
+});
 
 collada_element!("unit", Unit => {
     opt attrib name: String,
@@ -1698,6 +1788,10 @@ impl ColladaAttribute for UriFragment {
         Ok(UriFragment(String::from(trimmed)))
     }
 }
+
+collada_element!("vcount", VCount => {
+    contents: Vec<usize>
+});
 
 collada_element!("vertices", Vertices => {
     req attrib id: String

--- a/lib/parse_collada/src/lib.rs
+++ b/lib/parse_collada/src/lib.rs
@@ -1114,7 +1114,7 @@ collada_element!("mesh", Mesh => {
     rep child source: Source,
     rep child extra: Extra
 
-    rep enum primitive_elements: PrimitiveType {
+    rep enum primitive_elements: PrimitiveElements {
         "lines" => Lines(Lines),
         "linestrips" => Linestrips(Linestrips),
         "polygons" => Polygons(Polygons),
@@ -1365,7 +1365,7 @@ collada_element!("p", Primitive => {
 });
 
 #[derive(Debug, Clone)]
-pub enum PrimitiveType {
+pub enum PrimitiveElements {
     Lines(Lines),
     Linestrips(Linestrips),
     Polygons(Polygons),

--- a/lib/parse_collada/src/lib.rs
+++ b/lib/parse_collada/src/lib.rs
@@ -1,9 +1,10 @@
 extern crate parse_xml as xml;
 
+use std::convert::From;
 use std::fs::File;
+use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::str::FromStr;
-use std::convert::From;
 use xml::Event::*;
 
 #[derive(Debug, Clone, Default)]
@@ -71,6 +72,7 @@ pub enum Error {
         tag: String,
         text: String,
     },
+    InvalidUriFragment(String),
     ParseBoolError {
         text: String,
         error: std::str::ParseBoolError,
@@ -87,6 +89,7 @@ pub enum Error {
         parent: String,
         child: String,
     },
+    MissingTagContents(String),
 
     /// Indicates that a child that should have appeared at most one time appeared multiple times.
     RepeatingChild {
@@ -121,6 +124,106 @@ macro_rules! collada_element {
     };
 
     ($tag_name:expr, $struct_name:ident => {
+        contents: String
+    }) => {
+        #[derive(Debug, Clone)]
+        pub struct $struct_name(String);
+
+        impl ColladaElement for $struct_name {
+            fn parse(parser: &mut ColladaParser) -> Result<$struct_name> {
+                let mut contents: Option<String> = None;
+
+                loop {
+                    let event = parser.next_event();
+                    match event {
+                        TextNode(text) => {
+                            if contents.is_some() {
+                                return Err(Error::RepeatingChild {
+                                    parent: String::from($tag_name),
+                                    child: String::from("contents"),
+                                });
+                            }
+
+                            contents = Some(try!(parse_attrib::<String>(text)));
+                        }
+
+                        EndElement($tag_name) => break,
+                        _ => return Err(illegal_event(event, $tag_name)),
+                    }
+                }
+
+                Ok($struct_name(contents.unwrap_or(String::new())))
+            }
+        }
+
+        impl Deref for $struct_name {
+            type Target = String;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl DerefMut for $struct_name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+
+    ($tag_name:expr, $struct_name:ident => {
+        contents: $contents_type:ty
+    }) => {
+        #[derive(Debug, Clone)]
+        pub struct $struct_name($contents_type);
+
+        impl ColladaElement for $struct_name {
+            fn parse(parser: &mut ColladaParser) -> Result<$struct_name> {
+                let mut contents: Option<$contents_type> = None;
+
+                loop {
+                    let event = parser.next_event();
+                    match event {
+                        TextNode(text) => {
+                            if contents.is_some() {
+                                return Err(Error::RepeatingChild {
+                                    parent: String::from($tag_name),
+                                    child: String::from("contents"),
+                                });
+                            }
+
+                            contents = Some(try!(parse_attrib::<$contents_type>(text)));
+                        }
+
+                        EndElement($tag_name) => break,
+                        _ => return Err(illegal_event(event, $tag_name)),
+                    }
+                }
+
+                if contents.is_none() {
+                    return Err(Error::MissingTagContents(String::from($tag_name)));
+                }
+
+                Ok($struct_name(contents.unwrap() as $contents_type))
+            }
+        }
+
+        impl Deref for $struct_name {
+            type Target = $contents_type;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl DerefMut for $struct_name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
+
+    ($tag_name:expr, $struct_name:ident => {
         $(req attrib $req_attrib_name:ident: $req_attrib_type:ty),*
         $(opt attrib $opt_attrib_name:ident: $opt_attrib_type:ty),*
 
@@ -128,14 +231,18 @@ macro_rules! collada_element {
         $(opt child  $opt_child_name:ident:  $opt_child_type:ty),*
         $(rep child  $rep_child_name:ident:  $rep_child_type:ty),*
 
-        $(req enum child $req_enum_child_name:ident: $req_enum_child_type:ident {
+        $(req enum $req_enum_name:ident: $req_enum_type:ident {
             $($req_var_tag:expr => $req_var_name:ident($req_var_type:ty)),*
         }),*
-        $(opt enum child $opt_enum_child_name:ident: $opt_enum_child_type:ident {
+        $(opt enum $opt_enum_name:ident: $opt_enum_type:ident {
             $($opt_var_tag:expr => $opt_var_name:ident($opt_var_type:ty)),*
         }),*
-        // $(rep enum child ),*
+        $(rep enum $rep_enum_name:ident: $rep_enum_type:ident {
+            $($rep_var_tag:expr => $rep_var_name:ident($rep_var_type:ty)),*
+        }),*
+
         $(contents: $contents_type:ty),*
+        $(opt contents: $opt_contents_type:ty),*
     }) => {
         #[derive(Debug, Clone)]
         pub struct $struct_name {
@@ -146,10 +253,12 @@ macro_rules! collada_element {
             $(pub $opt_child_name:  Option<$opt_child_type>,)*
             $(pub $rep_child_name:  Vec<$rep_child_type>,)*
 
-            $(pub $req_enum_child_name: $req_enum_child_type,)*
-            $(pub $opt_enum_child_name: Option<$opt_enum_child_type>,)*
+            $(pub $req_enum_name: $req_enum_type,)*
+            $(pub $opt_enum_name: Option<$opt_enum_type>,)*
+            $(pub $rep_enum_name: Vec<$rep_enum_type>,)*
 
             $(pub contents: $contents_type,)*
+            $(pub contents: Option<$opt_contents_type>,)*
         }
 
         impl ColladaElement for $struct_name {
@@ -161,10 +270,12 @@ macro_rules! collada_element {
                 $(let mut $opt_child_name = None;)*
                 $(let mut $rep_child_name = Vec::new();)*
 
-                $(let mut $req_enum_child_name = None;)*
-                $(let mut $opt_enum_child_name = None;)*
+                $(let mut $req_enum_name = None;)*
+                $(let mut $opt_enum_name = None;)*
+                $(let mut $rep_enum_name = Vec::new();)*
 
                 $(let mut contents: Option<$contents_type> = None;)*
+                $(let mut contents: Option<$opt_contents_type> = None;)*
 
                 loop {
                     let event = parser.next_event();
@@ -232,15 +343,15 @@ macro_rules! collada_element {
                         $(
                             $(
                                 StartElement($req_var_tag) => {
-                                    if $req_enum_child_name.is_some() {
+                                    if $req_enum_name.is_some() {
                                         return Err(Error::RepeatingChild {
                                             parent: String::from($tag_name),
-                                            child: String::from(stringify!($req_enum_child_name)),
+                                            child: String::from(stringify!($req_enum_name)),
                                         });
                                     }
 
                                     let child: $req_var_type = try!(parse_element(parser));
-                                    $req_enum_child_name = Some($req_enum_child_type::$req_var_name(child));
+                                    $req_enum_name = Some($req_enum_type::$req_var_name(child));
                                 }
                             )*
                         )*
@@ -249,30 +360,56 @@ macro_rules! collada_element {
                         $(
                             $(
                                 StartElement($opt_var_tag) => {
-                                    if $opt_enum_child_name.is_some() {
+                                    if $opt_enum_name.is_some() {
                                         return Err(Error::RepeatingChild {
                                             parent: String::from($tag_name),
-                                            child: String::from(stringify!($opt_enum_child_name)),
+                                            child: String::from(stringify!($opt_enum_name)),
                                         });
                                     }
 
                                     let child: $opt_var_type = try!(parse_element(parser));
-                                    $opt_enum_child_name = Some($opt_enum_child_type::$opt_var_name(child));
+                                    $opt_enum_name = Some($opt_enum_type::$opt_var_name(child));
                                 }
                             )*
                         )*
 
-                        // Text node.
-                        $(TextNode(text) => {
-                            if contents.is_some() {
-                                return Err(Error::RepeatingChild {
-                                    parent: String::from($tag_name),
-                                    child: String::from(stringify!(contents)),
-                                });
-                            }
+                        // Repeating enum children.
+                        $(
+                            $(
+                                StartElement($rep_var_tag) => {
+                                    let child: $rep_var_type = try!(parse_element(parser));
+                                    $rep_enum_name.push($rep_enum_type::$rep_var_name(child));
+                                }
+                            )*
+                        )*
 
-                            contents = Some(try!(parse_attrib::<$contents_type>(text)));
-                        })*
+                        // Required text node.
+                        $(
+                            TextNode(text) => {
+                                if contents.is_some() {
+                                    return Err(Error::RepeatingChild {
+                                        parent: String::from($tag_name),
+                                        child: String::from("contents"),
+                                    });
+                                }
+
+                                contents = Some(try!(parse_attrib::<$contents_type>(text)));
+                            }
+                        )*
+
+                        // Optional text node.
+                        $(
+                            TextNode(text) => {
+                                if contents.is_some() {
+                                    return Err(Error::RepeatingChild {
+                                        parent: String::from($tag_name),
+                                        child: String::from("contents"),
+                                    });
+                                }
+
+                                contents = Some(try!(parse_attrib::<$opt_contents_type>(text)));
+                            }
+                        )*
 
                         EndElement($tag_name) => break,
                         _ => return Err(illegal_event(event, $tag_name)),
@@ -298,10 +435,10 @@ macro_rules! collada_element {
                 )*
 
                 $(
-                    if $req_enum_child_name.is_none() {
+                    if $req_enum_name.is_none() {
                         return Err(Error::MissingRequiredChild {
                             parent: String::from($tag_name),
-                            child: String::from(stringify!($req_enum_child_name)),
+                            child: String::from(stringify!($req_enum_name)),
                         });
                     }
                 )*
@@ -320,10 +457,12 @@ macro_rules! collada_element {
                     $($opt_child_name:  $opt_child_name,)*
                     $($rep_child_name:  $rep_child_name,)*
 
-                    $($req_enum_child_name: $req_enum_child_name.unwrap(),)*
-                    $($opt_enum_child_name: $opt_enum_child_name,)*
+                    $($req_enum_name: $req_enum_name.unwrap(),)*
+                    $($opt_enum_name: $opt_enum_name,)*
+                    $($rep_enum_name: $rep_enum_name,)*
 
                     $(contents: contents.unwrap() as $contents_type,)*
+                    $(contents: contents as Option<$opt_contents_type>,)*
                 })
             }
         }
@@ -456,7 +595,7 @@ impl ColladaAttribute for AltitudeMode {
 }
 
 collada_element!("ambient", AmbientFx => {
-    req enum child child: FxCommonColorOrTextureType {
+    req enum child: FxCommonColorOrTextureType {
         "color" => Color(Color),
         "param" => Param(ParamReference),
         "texture" => Texture(Texture)
@@ -575,7 +714,7 @@ collada_element!("created", Created => {
 });
 
 collada_element!("diffuse", Diffuse => {
-    req enum child child: FxCommonColorOrTextureType {
+    req enum child: FxCommonColorOrTextureType {
         "color" => Color(Color),
         "param" => Param(ParamReference),
         "texture" => Texture(Texture)
@@ -643,7 +782,7 @@ impl ColladaElement for Effect {
 }
 
 collada_element!("emission", Emission => {
-    req enum child child: FxCommonColorOrTextureType {
+    req enum child: FxCommonColorOrTextureType {
         "color" => Color(Color),
         "param" => Param(ParamReference),
         "texture" => Texture(Texture)
@@ -757,7 +896,7 @@ collada_element!("geometry", Geometry => {
     opt child asset: Asset
     rep child extra: Extra
 
-    req enum child geometric_element: GeometricElement {
+    req enum geometric_element: GeometricElement {
         "convex_mesh" => ConvexMesh(ConvexMesh),
         "mesh" => Mesh(Mesh),
         "spline" => Spline(Spline),
@@ -774,23 +913,22 @@ collada_element!("geographic_location", GeographicLocation => {
 collada_element!("IDREF_array", IdrefArray => {});
 
 collada_element!("index_of_refraction", IndexOfRefraction => {
-    req enum child child: FxCommonFloatOrParamType {
+    req enum child: FxCommonFloatOrParamType {
         "float" => Float(Float),
         "param" => Param(ParamReference)
     }
 });
 
-#[derive(Debug, Clone, Default)]
-pub struct InputShared {
-    pub offset: u32,
-    pub semantic: String,
-    pub source: String,
-    pub set: Option<u32>,
-}
+collada_element!("input", InputShared => {
+    req attrib offset: usize,
+    req attrib semantic: String,
+    req attrib source: UriFragment
+    opt attrib set: usize
+});
 
 collada_element!("input", InputUnshared => {
     req attrib semantic: String,
-    req attrib source: String
+    req attrib source: UriFragment
 });
 
 #[derive(Debug, Clone, Default)]
@@ -946,6 +1084,9 @@ collada_element!("library_visual_scenes", LibraryVisualScenes => {
     rep child extra: Extra
 });
 
+collada_element!("lines", Lines => {});
+collada_element!("linestrips", Linestrips => {});
+
 collada_element!("longitude", Longitude => {
     contents: f32
 });
@@ -968,55 +1109,21 @@ pub struct Matrix {
     pub data: [f32; 16],
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct Mesh {
-    pub source: Vec<Source>,
-    pub vertices: Vertices,
-    pub primitive_elements: Vec<PrimitiveType>,
-    pub extra: Vec<Extra>,
-}
+collada_element!("mesh", Mesh => {
+    req child vertices: Vertices
+    rep child source: Source,
+    rep child extra: Extra
 
-impl ColladaElement for Mesh {
-    fn parse(parser: &mut ColladaParser) -> Result<Mesh> {
-        let mut mesh = Mesh {
-            source: Vec::new(),
-            vertices: Vertices::new(),
-            primitive_elements: Vec::new(),
-            extra: Vec::new(),
-        };
-
-        loop {
-            let event = parser.next_event();
-            match event {
-                StartElement("source") => {
-                    let source = try!(parse_element(parser));
-                    mesh.source.push(source);
-                },
-                StartElement("vertices") => {
-                    mesh.vertices = try!(parser.parse_vertices());
-                },
-                StartElement("lines") => parser.parse_lines(),
-                StartElement("linestrips") => parser.parse_linestrips(),
-                StartElement("polygons") => parser.parse_polygons(),
-                StartElement("polylist") => parser.parse_polylist(),
-                StartElement("triangles") => {
-                    let triangles = try!(parse_element(parser));
-                    mesh.primitive_elements.push(PrimitiveType::Triangles(triangles));
-                },
-                StartElement("trifans") => parser.parse_trifans(),
-                StartElement("tristrips") => parser.parse_tristrips(),
-                StartElement("extra") => {
-                    let extra = try!(parse_element(parser));
-                    mesh.extra.push(extra);
-                },
-                EndElement("mesh") => break,
-                _ => return Err(illegal_event(event, "mesh"))
-            }
-        }
-
-        Ok(mesh)
+    rep enum primitive_elements: PrimitiveType {
+        "lines" => Lines(Lines),
+        "linestrips" => Linestrips(Linestrips),
+        "polygons" => Polygons(Polygons),
+        "polylist" => Polylist(Polylist),
+        "triangles" => Triangles(Triangles),
+        "trifans" => Trifans(Trifans),
+        "tristrips" => Tristrips(Tristrips)
     }
-}
+});
 
 collada_element!("modified", Modified => {
     contents: String
@@ -1250,16 +1357,22 @@ impl ColladaElement for Param {
 
 collada_element!("param", ParamReference => {});
 collada_element!("phong", Phong => {});
+collada_element!("polygons", Polygons => {});
+collada_element!("polylist", Polylist => {});
+
+collada_element!("p", Primitive => {
+    contents: Vec<usize>
+});
 
 #[derive(Debug, Clone)]
 pub enum PrimitiveType {
-    Lines,
-    Linestrips,
-    Polygons,
-    Polylist,
+    Lines(Lines),
+    Linestrips(Linestrips),
+    Polygons(Polygons),
+    Polylist(Polylist),
     Triangles(Triangles),
-    Trifans,
-    Tristrips
+    Trifans(Trifans),
+    Tristrips(Tristrips)
 }
 
 #[derive(Debug, Clone)]
@@ -1288,7 +1401,7 @@ collada_element!("profile_COMMON", ProfileCommon => {
 });
 
 collada_element!("reflective", Reflective => {
-    req enum child child: FxCommonColorOrTextureType {
+    req enum child: FxCommonColorOrTextureType {
         "color" => Color(Color),
         "param" => Param(ParamReference),
         "texture" => Texture(Texture)
@@ -1296,7 +1409,7 @@ collada_element!("reflective", Reflective => {
 });
 
 collada_element!("reflectivity", Reflectivity => {
-    req enum child child: FxCommonFloatOrParamType {
+    req enum child: FxCommonFloatOrParamType {
         "float" => Float(Float),
         "param" => Param(ParamReference)
     }
@@ -1390,7 +1503,7 @@ collada_element!("source", Source => {
     opt child technique_common: TechniqueCommon<Accessor>
     rep child technique: TechniqueCore
 
-    opt enum child array_element: ArrayElement {
+    opt enum array_element: ArrayElement {
         "bool_array" => Bool(BoolArray),
         "float_array" => Float(FloatArray),
         "IDREF_array" => Idref(IdrefArray),
@@ -1465,7 +1578,7 @@ collada_element!("technique", TechniqueFxCommon => {
     opt child asset: Asset
     rep child extra: Extra
 
-    req enum child shader_element: ShaderElementCommon {
+    req enum shader_element: ShaderElementCommon {
         "constant" => Constant(ConstantFx),
         "lambert" => Lambert(Lambert),
         "phong" => Phong(Phong),
@@ -1498,7 +1611,7 @@ pub struct Translate;
 collada_element!("transparent", Transparent => {
     opt attrib opaque: Opaque
 
-    req enum child child: FxCommonColorOrTextureType {
+    req enum child: FxCommonColorOrTextureType {
         "color" => Color(Color),
         "param" => Param(ParamReference),
         "texture" => Texture(Texture)
@@ -1506,70 +1619,24 @@ collada_element!("transparent", Transparent => {
 });
 
 collada_element!("transparency", Transparency => {
-    req enum child child: FxCommonFloatOrParamType {
+    req enum child: FxCommonFloatOrParamType {
         "float" => Float(Float),
         "param" => Param(ParamReference)
     }
 });
 
-#[derive(Debug, Clone, Default)]
-pub struct Triangles {
-    pub name: Option<String>,
-    pub count: usize,
-    pub material: Option<String>,
-    pub input: Vec<InputShared>,
-    pub p: Option<Vec<usize>>,
-    pub extra: Vec<Extra>,
-}
+collada_element!("triangles", Triangles => {
+    req attrib count: usize
+    opt attrib name: String,
+    opt attrib material: String
 
-impl ColladaElement for Triangles {
-    fn parse(parser: &mut ColladaParser) -> Result<Triangles> {
-        let mut triangles = Triangles {
-            name: None,
-            count: 0,
-            material: None,
-            input: Vec::new(),
-            p: None,
-            extra: Vec::new(),
-        };
+    opt child p: Primitive
+    rep child input: InputShared,
+    rep child extra: Extra
+});
 
-        loop {
-            let event = parser.next_event();
-            match event {
-                Attribute("name", name_str) => {
-                    triangles.name = Some(name_str.to_string());
-                },
-                Attribute("count", count_str) => {
-                    triangles.count = try!(usize::from_str(count_str).map_err(|err| {
-                        Error::ParseIntError {
-                            text: String::from(count_str),
-                            error: err,
-                        }
-                    }));
-                },
-                Attribute("material", material_str) => {
-                    triangles.material = Some(String::from(material_str));
-                },
-                StartElement("input") => {
-                    let input = try!(parser.parse_input_shared());
-                    triangles.input.push(input);
-                },
-                StartElement("p") => {
-                    let p = try!(parser.parse_p());
-                    triangles.p = Some(p);
-                },
-                StartElement("extra") => {
-                    let extra = try!(parse_element(parser));
-                    triangles.extra.push(extra);
-                },
-                EndElement("triangles") => break,
-                _ => return Err(illegal_event(event, "triangles"))
-            }
-        }
-
-        Ok(triangles)
-    }
-}
+collada_element!("trifans", Trifans => {});
+collada_element!("tristrips", Tristrips => {});
 
 collada_element!("unit", Unit => {
     opt attrib name: String,
@@ -1604,22 +1671,41 @@ impl ColladaElement for UpAxis {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-pub struct Vertices {
-    pub id: String,
-    pub name: Option<String>,
-    pub inputs: Vec<InputUnshared>,
-}
+#[derive(Debug, Clone)]
+pub struct UriFragment(String);
 
-impl Vertices {
-    pub fn new() -> Vertices {
-        Vertices {
-            id: String::new(),
-            name: None,
-            inputs: Vec::new(),
-        }
+impl Deref for UriFragment {
+    type Target = String;
+
+    fn deref(&self) -> &String {
+        &self.0
     }
 }
+
+impl DerefMut for UriFragment {
+    fn deref_mut(&mut self) -> &mut String {
+        &mut self.0
+    }
+}
+
+impl ColladaAttribute for UriFragment {
+    fn parse(text: &str) -> Result<UriFragment> {
+        if !text.starts_with("#") {
+            return Err(Error::InvalidUriFragment(String::from(text)));
+        }
+
+        let trimmed = text.trim_left_matches("#");
+        Ok(UriFragment(String::from(trimmed)))
+    }
+}
+
+collada_element!("vertices", Vertices => {
+    req attrib id: String
+    opt attrib name: String
+
+    rep child input: InputUnshared,
+    rep child extra: Extra
+});
 
 collada_element!("visual_scene", VisualScene => {
     opt attrib id: String,
@@ -1721,39 +1807,6 @@ impl<'a> ColladaParser<'a> {
         }
 
         Ok(collada)
-    }
-
-    fn parse_input_shared(&mut self) -> Result<InputShared> {
-        let mut input = InputShared {
-            offset: u32::max_value(),
-            semantic: String::new(),
-            source: String::new(),
-            set: None
-        };
-
-        loop {
-            let event = self.next_event();
-            match event {
-                Attribute("offset", offset_str) => {
-                    input.offset = u32::from_str(offset_str).unwrap();
-                },
-                Attribute("semantic", semantic_str) => {
-                    input.semantic.push_str(semantic_str);
-                },
-                Attribute("source", source_str) => {
-                    input.semantic.push_str(source_str);
-                },
-                Attribute("set", set_str) => {
-                    input.set = Some(u32::from_str(set_str).unwrap());
-                },
-                EndElement("input") => break,
-                _ => return Err(illegal_event(event, "input (shared)"))
-            }
-        }
-
-        assert!(input.offset != u32::max_value());
-
-        Ok(input)
     }
 
     fn parse_instance_camera(&mut self) -> Result<InstanceCamera> {
@@ -1885,18 +1938,6 @@ impl<'a> ColladaParser<'a> {
         self.skip_to_end_element("library_physics_scenes");
     }
 
-    fn parse_lines(&mut self) {
-        println!("Skipping over <lines> element");
-        println!("Warning: <lines> is not yet supported by parse_collada");
-        self.skip_to_end_element("lines");
-    }
-
-    fn parse_linestrips(&mut self) {
-        println!("Skipping over <linestrips> element");
-        println!("Warning: <linestrips> is not yet supported by parse_collada");
-        self.skip_to_end_element("linestrips");
-    }
-
     fn parse_lookat(&mut self) -> Result<LookAt> {
         println!("Skipping over <lookat> element");
         println!("Warning: <lookat> is not yet supported by parse_collada");
@@ -1942,85 +1983,12 @@ impl<'a> ColladaParser<'a> {
         Ok(matrix)
     }
 
-    fn parse_p(&mut self) -> Result<Vec<usize>> {
-        let mut primitives: Option<Vec<usize>> = None;
-
-        loop {
-            let event = self.next_event();
-            match event {
-                TextNode(text) => {
-                    let data = text.split_whitespace().map(|word| {
-                        let value = match usize::from_str(word) {
-                            Err(error) => return panic!("Error while parsing <float_array>: {}", error), // TODO: Return an error instead of panicking.
-                            Ok(value) => value
-                        };
-                        value
-                    }).collect::<Vec<usize>>();
-
-                    primitives = Some(data);
-                },
-                EndElement("p") => break,
-                _ => return Err(illegal_event(event, "p"))
-            }
-        }
-
-        Ok(primitives.unwrap())
-    }
-
-    fn parse_polygons(&mut self) {
-        println!("Skipping over <polygons> element");
-        println!("Warning: <polygons> is not yet supported by parse_collada");
-        self.skip_to_end_element("polygons");
-    }
-
-    fn parse_polylist(&mut self) {
-        println!("Skipping over <polylist> element");
-        println!("Warning: <polylist> is not yet supported by parse_collada");
-        self.skip_to_end_element("polylist");
-    }
-
     fn parse_translate(&mut self) -> Result<Translate> {
         println!("Skipping over <translate> element");
         println!("Warning: <translate> is not yet supported by parse_collada");
         self.skip_to_end_element("translate");
 
         Ok(Translate)
-    }
-
-    fn parse_trifans(&mut self) {
-        println!("Skipping over <trifans> element");
-        println!("Warning: <trifans> is not yet supported by parse_collada");
-        self.skip_to_end_element("trifans");
-    }
-
-    fn parse_tristrips(&mut self) {
-        println!("Skipping over <tristrips> element");
-        println!("Warning: <tristrips> is not yet supported by parse_collada");
-        self.skip_to_end_element("tristrips");
-    }
-
-    fn parse_vertices(&mut self) -> Result<Vertices> {
-        let mut vertices = Vertices::new();
-
-        loop {
-            let event = self.next_event();
-            match event {
-                Attribute("id", id_str) => {
-                    vertices.id.push_str(id_str);
-                },
-                Attribute("name", name_str) => {
-                    vertices.name = Some(String::from(name_str));
-                },
-                StartElement("input") => {
-                    let input = try!(parse_element(self));
-                    vertices.inputs.push(input);
-                },
-                EndElement("vertices") => break,
-                _ => return Err(illegal_event(event, "vertices")),
-            }
-        }
-
-        Ok(vertices)
     }
 
     /// Consumes all events until the desired one is reached.

--- a/lib/polygon_math/Cargo.toml
+++ b/lib/polygon_math/Cargo.toml
@@ -1,4 +1,4 @@
 [package]
 name = "polygon_math"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]

--- a/lib/polygon_math/src/lib.rs
+++ b/lib/polygon_math/src/lib.rs
@@ -11,8 +11,8 @@ pub mod quaternion;
 mod test;
 
 pub use self::point::Point;
-pub use self::vector::Vector3;
-pub use self::matrix::{Matrix4, Matrix3};
+pub use self::vector::{Vector2, Vector3};
+pub use self::matrix::{Matrix3, Matrix4};
 pub use self::color::Color;
 pub use self::quaternion::Quaternion;
 

--- a/lib/polygon_math/src/point.rs
+++ b/lib/polygon_math/src/point.rs
@@ -91,6 +91,16 @@ impl Point {
             slice::from_raw_parts(data, len * 4)
         }
     }
+
+    pub fn slice_as_f32_slice(raw: &[f32]) -> &[Point] {
+        assert!(raw.len() % 4 == 0, "To convert a slice of f32 to a slice of Point it must have a length that is a multiple of 4");
+
+        unsafe {
+            slice::from_raw_parts(
+                raw.as_ptr() as *const Point,
+                raw.len() / 4)
+        }
+    }
 }
 
 impl Sub for Point {

--- a/lib/polygon_math/src/point.rs
+++ b/lib/polygon_math/src/point.rs
@@ -92,7 +92,7 @@ impl Point {
         }
     }
 
-    pub fn slice_as_f32_slice(raw: &[f32]) -> &[Point] {
+    pub fn slice_from_f32_slice(raw: &[f32]) -> &[Point] {
         assert!(raw.len() % 4 == 0, "To convert a slice of f32 to a slice of Point it must have a length that is a multiple of 4");
 
         unsafe {

--- a/lib/polygon_math/src/vector.rs
+++ b/lib/polygon_math/src/vector.rs
@@ -99,6 +99,16 @@ impl Vector3 {
         self.x * self.x + self.y * self.y + self.z * self.z
     }
 
+    // Safely reinterprets a slice of Vector3s to a slice of f32s. This is a cheap operation and
+    // does not copy any data.
+    pub fn as_ref(vectors: &[Vector3]) -> &[f32] {
+        unsafe {
+            ::std::slice::from_raw_parts(
+                vectors.as_ptr() as *const f32,
+                vectors.len() * 3)
+        }
+    }
+
     // pub fn cross(&self, rhs: Vector3) -> Vector3 {
     //     Vector3::new(
     //         self.y * rhs.z - self.z * rhs.y,
@@ -277,6 +287,21 @@ impl IndexMut<usize> for Vector3 {
             2 => &mut self.z,
             // TODO: Use `unreachable()` intrinsic in release mode.
             _ => panic!("Index {} is out of bounds for Vector3", index),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+pub struct Vector2 {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Vector2 {
+    pub fn new(x: f32, y: f32) -> Vector2 {
+        Vector2 {
+            x: x,
+            y: y,
         }
     }
 }

--- a/lib/polygon_math/src/vector.rs
+++ b/lib/polygon_math/src/vector.rs
@@ -304,4 +304,14 @@ impl Vector2 {
             y: y,
         }
     }
+
+    pub fn as_ref(vectors: &[Vector2]) -> &[f32] {
+        use std::slice;
+
+        unsafe {
+            slice::from_raw_parts(
+                vectors.as_ptr() as *const f32,
+                vectors.len() * 2)
+        }
+    }
 }

--- a/lib/polygon_rs/Cargo.toml
+++ b/lib/polygon_rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "polygon"
-version = "0.0.1"
+version = "0.0.2"
 authors = ["David LeGare <excaliburhissheath@gmail.com>"]
 
 [dependencies.bootstrap-gl]

--- a/lib/polygon_rs/src/geometry/mesh.rs
+++ b/lib/polygon_rs/src/geometry/mesh.rs
@@ -1,49 +1,198 @@
+use math::*;
+
+pub type MeshIndex = u32;
+
 /// The raw data representing a mesh in memory.
 ///
 /// Meshes are represented as list of vertex positions and a list of faces.
 /// Each face is represented as 3 indices into the vertex array.
 #[derive(Debug)]
 pub struct Mesh {
-    pub raw_data: Vec<f32>,
-    pub indices: Vec<u32>,
-    pub position_attribute: VertexAttribute,
-    pub normal_attribute: Option<VertexAttribute>,
-    // pub uv_attribute:     Option<VertexAttribute>,
-    // pub color_attribute:  Option<VertexAttribute>,
+    vertex_data: Vec<f32>,
+    indices:     Vec<MeshIndex>,
+
+    position: VertexAttribute,
+    normal:   Option<VertexAttribute>,
+    texcoord: Vec<VertexAttribute>,
 }
 
 impl Mesh {
-    /// Create a new mesh from existing data passed as slices.
-    pub fn from_raw_data(positions_raw: &[f32], indices_raw: &[u32]) -> Mesh {
-        let mut raw_data: Vec<f32> = Vec::with_capacity(positions_raw.len());
-        raw_data.extend(positions_raw);
-
-        let mut indices: Vec<u32> = Vec::with_capacity(indices_raw.len());
-        indices.extend(indices_raw);
-
-        Mesh {
-            raw_data: raw_data,
-            indices: indices,
-            position_attribute: VertexAttribute {
-                stride: 4,
-                offset: 0,
-            },
-            normal_attribute: None,
-        }
+    pub fn vertex_data(&self) -> &[f32] {
+        &*self.vertex_data
     }
 
-    /// Adds the normals data to the mesh's raw data and creates the associated `VertexAttribute`.
-    pub fn add_normals(&mut self, normals_raw: &[f32]) {
-        self.normal_attribute = Some(VertexAttribute {
-            stride: 3,
-            offset: self.raw_data.len(),
-        });
-        self.raw_data.extend(normals_raw);
+    pub fn indices(&self) -> &[MeshIndex] {
+        &*self.indices
+    }
+
+    pub fn position(&self) -> VertexAttribute {
+        self.position
+    }
+
+    pub fn normal(&self) -> Option<VertexAttribute> {
+        self.normal
+    }
+
+    pub fn texcoord(&self) -> &[VertexAttribute] {
+        &*self.texcoord
+    }
+}
+
+/// Represents a single vertex in a mesh with all of its supported attributes.
+#[derive(Debug, Clone)]
+pub struct Vertex {
+    pub position: Point,
+    pub normal: Option<Vector3>,
+
+    /// Support an arbitrary number of texture units. The actual maximum is dependent on hardware
+    /// and so is not limited by polygon directly. If the number of
+    pub texcoord: Vec<Vector2>,
+}
+
+impl Vertex {
+    pub fn new(position: Point) -> Vertex {
+        Vertex {
+            position: position,
+            normal: None,
+            texcoord: Vec::new(),
+        }
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct VertexAttribute {
-    pub stride: usize,
     pub offset: usize,
+    pub stride: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum BuildMeshError {
+    IndexOutOfBounds {
+        vertex_count: MeshIndex,
+        index: MeshIndex,
+    },
+
+    /// Indicates that one or more attributes had a count that did not match the total number of
+    /// vertices.
+    IncorrectAttributeCount,
+}
+
+#[derive(Debug, Clone)]
+pub struct MeshBuilder {
+    position_data: Vec<Point>,
+    normal_data: Vec<Vector3>,
+    texcoord_data: Vec<Vec<Vector3>>,
+
+    indices:  Vec<u32>,
+}
+
+// TODO: I'd like to support building the mesh by specifying all of each attribute at once, since
+// that seems like a common use case for game development. We still want to support building it
+// vert-by-vert because that works best in other situations (e.g. COLLADA files).
+impl MeshBuilder {
+    pub fn new() -> MeshBuilder {
+        MeshBuilder {
+            position_data: Vec::new(),
+            normal_data:   Vec::new(),
+            texcoord_data: Vec::new(),
+            indices:       Vec::new(),
+        }
+    }
+
+    pub fn add_vertex(mut self, vertex: Vertex) -> MeshBuilder {
+        self.position_data.push(vertex.position);
+
+        if let Some(normal) = vertex.normal {
+            self.normal_data.push(normal);
+        }
+
+        // TODO: Handle texcoord data.
+
+        self
+    }
+
+    pub fn add_index(mut self, index: MeshIndex) -> MeshBuilder {
+        self.indices.push(index);
+        self
+    }
+
+    pub fn set_position_data(mut self, position_data: &[Point]) -> MeshBuilder {
+        self.position_data.clear();
+        self.position_data.extend(position_data);
+        self
+    }
+
+    pub fn set_normal_data(mut self, normal_data: &[Vector3]) -> MeshBuilder {
+        self.normal_data.clear();
+        self.normal_data.extend(normal_data);
+        self
+    }
+
+    pub fn set_texcoord_data(mut self, _texcoord_data: &[Vector2], _texcoord_index: MeshIndex) -> MeshBuilder {
+        // TODO
+
+        self
+    }
+
+    pub fn set_indices(mut self, indices: &[u32]) -> MeshBuilder {
+        self.indices.clear();
+        self.indices.extend(indices);
+        self
+    }
+
+    pub fn build(self) -> Result<Mesh, BuildMeshError> {
+        // Validate the mesh data.
+
+        // The vertex count is defined by the position data, since position is the only required
+        // vertex attribute.
+        let vertex_count = self.position_data.len();
+
+        // TODO: Validate texcoord data.
+        if self.normal_data.len() != 0 && self.normal_data.len() != vertex_count {
+            return Err(BuildMeshError::IncorrectAttributeCount);
+        }
+
+        // Make sure all indices at least point to a valid vertex.
+        for index in self.indices.iter().cloned() {
+            if index >= vertex_count as MeshIndex {
+                return Err(BuildMeshError::IndexOutOfBounds {
+                    vertex_count: vertex_count as MeshIndex,
+                    index: index,
+                });
+            }
+        }
+
+        // TODO: Make sure all normals are normalized?
+
+        // Create the mesh.
+        let mut vertex_data =
+            Vec::<f32>::with_capacity(
+                self.position_data.len() * 4
+              + self.normal_data.len() * 3);
+        vertex_data.extend(Point::as_ref(&*self.position_data));
+        vertex_data.extend(Vector3::as_ref(&*self.normal_data));
+
+        // TODO: Add texcoord data.
+
+        Ok(Mesh {
+            vertex_data: vertex_data,
+            indices: self.indices,
+
+            position: VertexAttribute {
+                offset: 0,
+                stride: 0, // TODO: Should stride 4 (as in every 4 floats) or 0 (as in tightly packed)? Does that change between OpenGL and DirectX?
+            },
+
+            normal: if self.normal_data.len() > 0 {
+                Some(VertexAttribute {
+                    offset: self.position_data.len() * 4,
+                    stride: 0, // TODO: Same as above.
+                })
+            } else {
+                None
+            },
+
+            texcoord: Vec::new(),
+        })
+    }
 }

--- a/lib/polygon_rs/src/geometry/mesh.rs
+++ b/lib/polygon_rs/src/geometry/mesh.rs
@@ -86,9 +86,18 @@ pub struct MeshBuilder {
     indices:  Vec<u32>,
 }
 
-// TODO: I'd like to support building the mesh by specifying all of each attribute at once, since
-// that seems like a common use case for game development. We still want to support building it
-// vert-by-vert because that works best in other situations (e.g. COLLADA files).
+/// Provides a safe interface for building a mesh from raw vertex data.
+///
+/// `MeshBuilder` supports two methods for specifying mesh data: Providing a series of `Vertex`
+/// objects, or directly setting the data for each vertex attribute at once. Once all vertex data
+/// has been set calling `build()` will validate the mesh data and produce a `Mesh` object.
+///
+/// The mesh builder performs validity tests when building the mesh and mesh compilation can fail
+/// if the mesh data is invalid in some way. The following validity tests are performed:
+///
+/// - Check for different data count for different attributes (e.g. if the position attribute data
+///   for a different number of elements than the normal attribute).
+/// - Any of the indicies would be out of bounds for the given vertex data.
 impl MeshBuilder {
     pub fn new() -> MeshBuilder {
         MeshBuilder {

--- a/lib/polygon_rs/src/geometry/mesh.rs
+++ b/lib/polygon_rs/src/geometry/mesh.rs
@@ -180,13 +180,13 @@ impl MeshBuilder {
 
             position: VertexAttribute {
                 offset: 0,
-                stride: 0, // TODO: Should stride 4 (as in every 4 floats) or 0 (as in tightly packed)? Does that change between OpenGL and DirectX?
+                stride: 4,
             },
 
             normal: if self.normal_data.len() > 0 {
                 Some(VertexAttribute {
                     offset: self.position_data.len() * 4,
-                    stride: 0, // TODO: Same as above.
+                    stride: 3,
                 })
             } else {
                 None

--- a/lib/polygon_rs/src/geometry/mod.rs
+++ b/lib/polygon_rs/src/geometry/mod.rs
@@ -1,3 +1,3 @@
 pub mod mesh;
 
-pub use self::mesh::{Mesh, VertexAttribute};
+pub use self::mesh::*;

--- a/lib/polygon_rs/src/gl_render.rs
+++ b/lib/polygon_rs/src/gl_render.rs
@@ -69,7 +69,7 @@ impl GLRender {
 
         gl.buffer_data(
             BufferTarget::ArrayBuffer,
-            &*mesh.raw_data,
+            mesh.vertex_data(),
             BufferUsage::StaticDraw);
 
         let index_buffer = gl.gen_buffer();
@@ -77,7 +77,7 @@ impl GLRender {
 
         gl.buffer_data(
             BufferTarget::ElementArrayBuffer,
-            &*mesh.indices,
+            mesh.indices(),
             BufferUsage::StaticDraw);
 
         // Unbind buffers.
@@ -89,9 +89,9 @@ impl GLRender {
             vertex_array: vertex_array,
             vertex_buffer: vertex_buffer,
             index_buffer: index_buffer,
-            position_attribute: mesh.position_attribute,
-            normal_attribute: mesh.normal_attribute,
-            element_count: mesh.indices.len(),
+            position_attribute: mesh.position(),
+            normal_attribute: mesh.normal(),
+            element_count: mesh.indices().len(),
         }
     }
 

--- a/lib/polygon_rs/src/lib.rs
+++ b/lib/polygon_rs/src/lib.rs
@@ -1,12 +1,13 @@
-extern crate polygon_math as math;
-extern crate bootstrap_rs as bootstrap;
 extern crate bootstrap_gl as gl;
+extern crate bootstrap_rs as bootstrap;
+extern crate polygon_math as math;
 
+pub mod camera;
 pub mod geometry;
 pub mod gl_render;
-pub mod camera;
 pub mod light;
 
 pub use camera::Camera;
-pub use light::{Light, PointLight};
+pub use geometry::*;
 pub use gl_render::{GLRender, ShaderProgram};
+pub use light::{Light, PointLight};

--- a/src/debug_draw.rs
+++ b/src/debug_draw.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 use math::*;
 use polygon::Camera;
 use polygon::gl_render::{GLRender, ShaderProgram, GLMeshData};
-use polygon::geometry::Mesh;
+use polygon::geometry::*;
 use resource::ResourceManager;
 
 static mut instance: *const Mutex<DebugDrawInner> = 0 as *const _;
@@ -35,7 +35,7 @@ static CUBE_VERTS: [f32; 32] =
      -0.5,  0.5, -0.5, 1.0,
      -0.5, -0.5,  0.5, 1.0,
      -0.5, -0.5, -0.5, 1.0,];
-static CUBE_INDICES: [u32; 24] =
+static CUBE_INDICES: [MeshIndex; 24] =
     [0, 1,
      1, 3,
      3, 2,
@@ -178,8 +178,13 @@ impl Drop for DebugDraw {
 }
 
 /// Creates a mesh from a list of vertices and indices.
-fn build_mesh(renderer: &GLRender, vertices: &[f32], indices: &[u32]) -> GLMeshData {
-    let mesh = Mesh::from_raw_data(vertices, indices);
+fn build_mesh(renderer: &GLRender, vertices: &[f32], indices: &[MeshIndex]) -> GLMeshData {
+    let mesh = MeshBuilder::new()
+    .set_position_data(Point::slice_from_f32_slice(vertices))
+    .set_indices(indices)
+    .build()
+    .unwrap(); // TODO: Don't panic? I think in this case panicking is a bug in the engine and is pretty legit.
+
     renderer.gen_mesh(&mesh)
 }
 

--- a/src/gunship.rs
+++ b/src/gunship.rs
@@ -2,7 +2,6 @@
 
 extern crate bootstrap_rs as bootstrap;
 extern crate bootstrap_audio as bs_audio;
-extern crate parse_collada as collada;
 extern crate polygon;
 extern crate polygon_math as math;
 extern crate hash;

--- a/src/resource/collada.rs
+++ b/src/resource/collada.rs
@@ -2,11 +2,22 @@ extern crate parse_collada as collada;
 
 pub use self::collada::{ArrayElement, Collada, GeometricElement, Geometry, Node, PrimitiveElements, VisualScene};
 
-use polygon::geometry::mesh::Mesh;
+use math::*;
+use polygon::geometry::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub enum Error {
+    /// Indicates an error that occurred when the MeshBuilder was validating the mesh data. If the
+    /// COLLADA document passed parsing this should not occur.
+    BuildMeshError(BuildMeshError),
+
+    IncorrectPrimitiveIndicesCount {
+        primitive_count: usize,
+        stride: usize,
+        index_count: usize,
+    },
+
     /// Indicates that there was an input with the "NORMAL" semantic but the associated source
     /// was missing.
     MissingNormalSource,
@@ -28,12 +39,26 @@ pub enum Error {
     /// fixed.
     MissingPositionSemantic,
 
+    /// Indicates that the <mesh> had no primitive elements.
+    MissingPrimitiveElement,
+
+    /// Indicates that one of the primitive elements (e.g. <trianges> et al) were missing a <p>
+    /// child element. While this is technically allowed by the standard I'm not really sure what
+    /// to do with that? Like how do you define a mesh without indices?
+    MissingPrimitiveIndices,
+
     UnsupportedGeometricElement,
     UnsupportedPrimitiveType,
     UnsupportedSourceElement,
 }
 
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+pub enum VertexSemantic {
+    Position,
+    Normal,
+    TexCoord,
+}
 
 /// Load the mesh data from a COLLADA .dae file.
 ///
@@ -51,65 +76,123 @@ pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Mesh> {
 }
 
 fn collada_mesh_to_mesh(mesh: &collada::Mesh) -> Result<Mesh> {
-    let position_data_raw = try!(get_raw_positions(&mesh));
+    // First, pick a primitive element to parse into a Mesh.
+    // TODO: Handle all primitive elements in the mesh, not just one. This is dependent on polygon
+    // being able to support submeshes.
+    let primitive = try!(
+        mesh.primitive_elements.first()
+        .ok_or(Error::MissingPrimitiveElement));
 
-    let triangles = match mesh.primitive_elements[0] {
+    // TODO: A mesh may have no primitive elements and still be well-formed by the COLLADA spec.
+    // We need to gracefully handle that case by either returning and error about unsupported
+    // format or return an empty mesh (which is what a mesh with no primitives is).
+    let triangles = match *primitive {
         PrimitiveElements::Triangles(ref triangles) => triangles,
         _ => return Err(Error::UnsupportedPrimitiveType),
     };
 
-    let normal_data_raw = try!(get_normals_for_triangles(mesh, triangles)).unwrap(); // TODO: Handle the case where there's no normal data.
-    let primitive_indices = &triangles.p.as_ref().unwrap();
-
-    // Create a new array for the positions so we can add the w coordinate.
-    let mut position_data: Vec<f32> = Vec::with_capacity(position_data_raw.len() / 3 * 4);
-
-    // Create a new array for the normals and rearrange them to match the order of position attributes.
-    let mut normal_data: Vec<f32> = Vec::with_capacity(position_data.len());
+    let primitive_indices = try!(
+        triangles.p
+        .as_ref()
+        .ok_or(Error::MissingPrimitiveIndices));
 
     // Iterate over the indices, rearranging the normal data to match the position data.
-    let stride = mesh.source.len(); // TODO: Do we have a better way of calculating stride? What if one of the sources isn't used? OR USED TWICE!?
-    let mut vertex_index_map: HashMap<(usize, usize), u32> = HashMap::new();
-    let mut indices: Vec<u32> = Vec::new();
-    let vertex_count = triangles.count * 3;
-    let mut index_count = 0;
-    for offset in 0..vertex_count {
-        // Determine the offset of the the current vertex's attributes
-        let position_index = primitive_indices[offset * stride];
-        let normal_index = primitive_indices[offset * stride + 1];
+    let stride = triangles.input.len(); // TODO: Do we have a better way of calculating stride? What if one of the sources isn't used? OR USED TWICE!?
+    let count  = triangles.count;
+    let index_count = primitive_indices.len();
+    let vertex_count = count as u32 * 3;
 
-        // Push the index of the vertex, either reusing an existing vertex or creating a new one.
-        let vertex_key = (position_index, normal_index);
-        let vertex_index = if vertex_index_map.contains_key(&vertex_key) {
-            // Vertex has already been assembled, reuse the index.
-            (*vertex_index_map.get(&vertex_key).unwrap()) as u32
-        } else {
-            // Assemble new vertex.
-            let vertex_index = index_count;
-            index_count += 1;
-            vertex_index_map.insert(vertex_key, vertex_index as u32);
-
-            // Append position to position data array.
-            for offset in 0..3 {
-                position_data.push(position_data_raw[position_index * 3 + offset]);
-            }
-            position_data.push(1.0);
-
-            // Append normal to normal data array.
-            for offset in 0..3 {
-                normal_data.push(normal_data_raw[normal_index * 3 + offset]);
-            }
-
-            vertex_index
-        };
-
-        indices.push(vertex_index);
+    // Verify we have the right number of indices to build the vertices.
+    if count * stride * 3 != index_count {
+        return Err(Error::IncorrectPrimitiveIndicesCount {
+            primitive_count: count,
+            stride: stride,
+            index_count: index_count,
+        });
     }
 
-    let mut mesh = Mesh::from_raw_data(position_data.as_ref(), indices.as_ref());
-    mesh.add_normals(normal_data.as_ref());
+    // Retrieve the f32 arrays for position and normal data.
+    let position_data_raw = try!(get_raw_positions(&mesh));
+    let normal_data_raw = try!(get_normals_for_element(mesh, primitive));
 
-    Ok(mesh)
+    // The indices list is a just a raw list of indices. They are implicity grouped based on the
+    // number of inputs for the primitive element (e.g. if there are 3 inputs for the primitive
+    // then there are 3 indices per vertex). To handle this we use GroupBy to do a strided
+    // iteration over indices list and build each vertex one at a time. Internally the mesh
+    // builder handles the details of how to assemble the vertex data in memory.
+
+    // Build a mapping between the vertex indices and the source that they use.
+    let mut source_map = Vec::new();
+    for (offset, input) in triangles.input.iter().enumerate() {
+        // Retrieve the approriate source. If the semantic is "VERTEX" then the offset is
+        // associated with all of the sources specified by the <vertex> element.
+        let source_ids = match &*input.semantic {
+            "VERTEX" => {
+                mesh.vertices.input
+                .iter()
+                .map(|input| &*input.semantic)
+                .collect()
+            },
+            _ => vec![(&*input.semantic)],
+        };
+
+        // For each of the semantics at the current offset, push their info into the source map.
+        for semantic in source_ids {
+            source_map.push((offset, semantic));
+        }
+    }
+
+    let mut mesh_builder = MeshBuilder::new();
+    let mut unsupported_semantic_flag = false;
+    for vertex_indices in GroupBy::new(primitive_indices, stride).unwrap() { // TODO: This can't fail... right? I'm pretty sure the above checks make sure this is correct.
+        // We iterate over each group of indices where each group represents the indices for a
+        // single vertex. Within that vertex we need
+        let mut vertex = Vertex::new(Point::origin());
+
+        for (offset, index) in vertex_indices.iter().enumerate() {
+            let mut filter =
+                source_map.iter()
+                .filter(|map| map.0 == offset)
+                .map(|&(_, semantic)| semantic);
+            for semantic in filter {
+                match &*semantic {
+                    "POSITION" => {
+                        vertex.position = Point::new(
+                            // TODO: Don't assume that the position data is encoded as 3 coordinate
+                            // vectors. The <technique_common> element for the source should have
+                            // an <accessor> describing how the data is laid out.
+                            position_data_raw[index * 3 + 0],
+                            position_data_raw[index * 3 + 1],
+                            position_data_raw[index * 3 + 2],
+                        );
+                    },
+                    "NORMAL" => {
+                        let normal_data = try!(
+                            normal_data_raw
+                            .ok_or(Error::MissingNormalData));
+                        vertex.normal = Some(Vector3::new(
+                            normal_data[index * 3 + 0],
+                            normal_data[index * 3 + 1],
+                            normal_data[index * 3 + 2],
+                        ));
+                    }
+                    _ => if !unsupported_semantic_flag {
+                        unsupported_semantic_flag = true;
+                        println!("WARNING: Unsupported vertex semantic {} in mesh will not be used", semantic);
+                    },
+                }
+            }
+        }
+
+        mesh_builder = mesh_builder.add_vertex(vertex);
+    }
+
+    let indices: Vec<u32> = (0..vertex_count).collect();
+
+    mesh_builder
+    .set_indices(&*indices)
+    .build()
+    .map_err(|err| Error::BuildMeshError(err))
 }
 
 /// Parses the <mesh> element to find the <source> element associated with the "POSITION" input semantic.
@@ -152,7 +235,8 @@ fn get_raw_positions(mesh: &collada::Mesh) -> Result<&[f32]> {
     Ok(position_data)
 }
 
-fn get_normals_for_triangles<'a>(mesh: &'a collada::Mesh, triangles: &'a collada::Triangles) -> Result<Option<&'a [f32]>> {
+// TODO: This shouldn't be specific to triangles, it should work for all PrimitiveElements variants
+fn get_normals_for_element<'a>(mesh: &'a collada::Mesh, element: &'a PrimitiveElements) -> Result<Option<&'a [f32]>> {
     // First we have to find the input with the correct semantic.
     // Check the mesh's <vertices> element first.
     let source_id = {
@@ -163,7 +247,7 @@ fn get_normals_for_triangles<'a>(mesh: &'a collada::Mesh, triangles: &'a collada
             .find(|input| input.semantic == "NORMAL")
             .map(|input| &input.source)
             .or_else(||
-                triangles.input
+                element.input()
                 .iter()
                 .find(|input| input.semantic == "NORMAL")
                 .map(|input| &input.source)
@@ -200,4 +284,44 @@ fn get_normals_for_triangles<'a>(mesh: &'a collada::Mesh, triangles: &'a collada
     };
 
     Ok(Some(normal_data))
+}
+
+// TODO: Where even should this live? It's generally useful but I'm only using it here right now.
+struct GroupBy<'a, T: 'a> {
+    next:     *const T,
+    end:      *const T,
+    stride:   usize,
+    _phantom: ::std::marker::PhantomData<&'a T>,
+}
+
+impl<'a, T: 'a> GroupBy<'a, T> {
+    fn new(slice: &'a [T], stride: usize) -> ::std::result::Result<GroupBy<'a, T>, ()> {
+        if slice.len() % stride != 0 {
+            return Err(());
+        }
+
+        Ok(GroupBy {
+            next: slice.as_ptr(),
+            end: unsafe { slice.as_ptr().offset(slice.len() as isize) },
+            stride: stride,
+            _phantom: ::std::marker::PhantomData,
+        })
+    }
+}
+
+impl<'a, T: 'a> Iterator for GroupBy<'a, T> {
+    type Item = &'a [T];
+
+    fn next(&mut self) -> Option<&'a [T]> {
+        if self.next == self.end {
+            return None;
+        }
+
+        let next = self.next;
+        self.next = unsafe { self.next.offset(self.stride as isize) };
+
+        Some(unsafe {
+            ::std::slice::from_raw_parts(next, self.stride)
+        })
+    }
 }

--- a/src/resource/collada.rs
+++ b/src/resource/collada.rs
@@ -1,0 +1,138 @@
+extern crate parse_collada as collada;
+
+pub use self::collada::{ArrayElement, Collada, GeometricElement, Geometry, Node, PrimitiveType, VisualScene};
+
+use polygon::geometry::mesh::Mesh;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub enum Error {
+    MissingPositionData,
+
+    /// Indicates that a <vertices> element had and <input> element with no "POSITION" semantic.
+    ///
+    /// NOTE: This error means that the COLLADA document is ill-formed and should have failed
+    /// parsing. This indicates that there is a bug in the parse-collada library that should be
+    /// fixed.
+    MissingPositionSemantic,
+
+    UnsupportedGeometricElement,
+    UnsupportedPrimitiveType,
+    UnsupportedSourceElement,
+}
+
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// Load the mesh data from a COLLADA .dae file.
+///
+/// The data in a COLLADA files is formatted for efficiency, but isn't necessarily
+/// organized in a way that is supported by the graphics API. This method reformats the
+/// data so that it can be sent straight to the GPU without further manipulation.
+///
+/// In order to to this, it reorganizes the normals, UVs, and other vertex attributes to
+/// be in the same order as the vertex positions.
+pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Mesh> {
+    match geometry.geometric_element {
+        GeometricElement::Mesh(ref mesh) => collada_mesh_to_mesh(mesh),
+        _ => Err(Error::UnsupportedGeometricElement),
+    }
+}
+
+fn collada_mesh_to_mesh(mesh: &collada::Mesh) -> Result<Mesh> {
+    let position_data_raw = try!(get_raw_positions(&mesh));
+    let normal_data_raw = try!(get_normals(&mesh));
+
+    let triangles = match mesh.primitive_elements[0] {
+        PrimitiveType::Triangles(ref triangles) => triangles,
+        _ => return Err(Error::UnsupportedPrimitiveType),
+    };
+    let primitive_indices = &triangles.p.as_ref().unwrap();
+
+    // Create a new array for the positions so we can add the w coordinate.
+    let mut position_data: Vec<f32> = Vec::with_capacity(position_data_raw.len() / 3 * 4);
+
+    // Create a new array for the normals and rearrange them to match the order of position attributes.
+    let mut normal_data: Vec<f32> = Vec::with_capacity(position_data.len());
+
+    // Iterate over the indices, rearranging the normal data to match the position data.
+    let stride = mesh.source.len(); // TODO: Do we have a better way of calculating stride? What if one of the sources isn't used? OR USED TWICE!?
+    let mut vertex_index_map: HashMap<(usize, usize), u32> = HashMap::new();
+    let mut indices: Vec<u32> = Vec::new();
+    let vertex_count = triangles.count * 3;
+    let mut index_count = 0;
+    for offset in 0..vertex_count {
+        // Determine the offset of the the current vertex's attributes
+        let position_index = primitive_indices[offset * stride];
+        let normal_index = primitive_indices[offset * stride + 1];
+
+        // Push the index of the vertex, either reusing an existing vertex or creating a new one.
+        let vertex_key = (position_index, normal_index);
+        let vertex_index = if vertex_index_map.contains_key(&vertex_key) {
+            // Vertex has already been assembled, reuse the index.
+            (*vertex_index_map.get(&vertex_key).unwrap()) as u32
+        } else {
+            // Assemble new vertex.
+            let vertex_index = index_count;
+            index_count += 1;
+            vertex_index_map.insert(vertex_key, vertex_index as u32);
+
+            // Append position to position data array.
+            for offset in 0..3 {
+                position_data.push(position_data_raw[position_index * 3 + offset]);
+            }
+            position_data.push(1.0);
+
+            // Append normal to normal data array.
+            for offset in 0..3 {
+                normal_data.push(normal_data_raw[normal_index * 3 + offset]);
+            }
+
+            vertex_index
+        };
+
+        indices.push(vertex_index);
+    }
+
+    let mut mesh = Mesh::from_raw_data(position_data.as_ref(), indices.as_ref());
+    mesh.add_normals(normal_data.as_ref());
+
+    Ok(mesh)
+}
+
+fn get_raw_positions(mesh: &collada::Mesh) -> Result<&[f32]> {
+    let pos_input = try!(
+        mesh.vertices.input
+        .iter()
+        .find(|input| input.semantic == "POSITION")
+        .ok_or(Error::MissingPositionSemantic));
+    let pos_source_id = &*pos_input.source;
+
+    let position_source = try!(
+        mesh.source
+        .iter()
+        .find(|source| source.id == *pos_source_id)
+        .ok_or(Error::MissingPositionSemantic));
+
+    let position_element: &collada::ArrayElement = try!(
+        position_source.array_element
+        .as_ref()
+        .ok_or(Error::MissingPositionData));
+
+    let position_data: &[f32] = match *position_element {
+        ArrayElement::Float(ref float_array) => float_array.contents.as_ref(),
+        _ => return Err(Error::UnsupportedSourceElement),
+    };
+
+    Ok(position_data)
+}
+
+fn get_normals(mesh: &collada::Mesh) -> Result<&[f32]> {
+    // TODO: Consult the correct element (<triangles> for now) to determine which source has normal data.
+    let normal_data: &[f32] = match *mesh.source[1].array_element.as_ref().unwrap() {
+        ArrayElement::Float(ref float_array) => float_array.contents.as_ref(),
+        _ => panic!("Only float arrays supported for vertex normal array")
+    };
+    assert!(normal_data.len() > 0);
+
+    Ok(normal_data)
+}

--- a/src/resource/collada.rs
+++ b/src/resource/collada.rs
@@ -78,6 +78,10 @@ pub fn geometry_to_mesh(geometry: &Geometry) -> Result<Mesh> {
 }
 
 fn collada_mesh_to_mesh(mesh: &collada::Mesh) -> Result<Mesh> {
+    if mesh.primitive_elements.len() > 1 {
+        println!("WARNING: Mesh is composed of more than one geometric primitive, which is not currently supported, only part of the mesh will be loaded");
+    }
+
     // Grab the first primitive element in the mesh.
     // TODO: Handle all primitive elements in the mesh, not just one. This is dependent on polygon
     // being able to support submeshes.

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -16,8 +16,8 @@ use component::{MeshManager, TransformManager};
 use self::collada::{Collada, Geometry, Node, VisualScene};
 use self::shader::*;
 
-mod collada;
-mod shader;
+pub mod collada;
+pub mod shader;
 
 #[derive(Debug, Clone)]
 pub struct ResourceManager {

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -99,7 +99,7 @@ impl ResourceManager {
         Ok(())
     }
 
-    /// Sets the path to the resources director.
+    /// Sets the path to the resources directory.
     ///
     /// # Details
     ///

--- a/src/resource/shader.rs
+++ b/src/resource/shader.rs
@@ -1,0 +1,92 @@
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ParseShaderError {
+    NoVertProgram,
+    NoFragProgram,
+    MultipleVertShader,
+    MultipleFragShader,
+    ProgramMissingName,
+    UnmatchedBraces,
+    MissingOpeningBrace,
+    CompileError(String),
+    LinkError(String),
+}
+
+#[derive(Debug, Clone)]
+pub struct ShaderParser;
+
+#[derive(Debug, Clone)]
+pub struct ShaderProgramSrc<'a> {
+    pub name: &'a str,
+    pub src: &'a str,
+}
+
+impl ShaderParser {
+    pub fn parse(shader_src: &str) -> Result<Vec<ShaderProgramSrc>, ParseShaderError> {
+        let mut programs: Vec<ShaderProgramSrc> = Vec::new();
+        let mut index = 0;
+        loop {
+            let substr = &shader_src[index..];
+            let (program, end_index) = try!(ShaderParser::parse_program(substr));
+            programs.push(program);
+            index = end_index;
+
+            if programs.len() >= 2 {
+                break;
+            }
+        }
+
+        Ok(programs)
+    }
+
+    fn parse_program(src: &str) -> Result<(ShaderProgramSrc, usize), ParseShaderError> {
+        if let Some(index) = src.find("program") {
+            let program_src = src[index..].trim_left();
+            let program_name = match program_src.split_whitespace().nth(1) {
+                Some(name) => name,
+                None => return Err(ParseShaderError::ProgramMissingName),
+            };
+
+            let (program_src, end_index) = match program_src.find('{') {
+                None => return Err(ParseShaderError::MissingOpeningBrace),
+                Some(index) => {
+                    let (src, index) = try!(ShaderParser::parse_braces_contents(&program_src[index..]));
+                    (src.trim(), index)
+                }
+            };
+
+            let program = ShaderProgramSrc {
+                name: program_name,
+                src: program_src,
+            };
+            Ok((program, end_index))
+        } else {
+            return Err(ParseShaderError::NoVertProgram);
+        }
+    }
+
+    /// Parses the contents of a curly brace-delimeted block.
+    ///
+    /// Retuns a substring of the source string that contains the contents of the block without
+    /// the surrounding curly braces. Fails if there is no matching close brace.
+    fn parse_braces_contents(src: &str) -> Result<(&str, usize), ParseShaderError> {
+        assert!(src.starts_with("{"));
+
+        let mut depth = 0;
+        for (index, character) in src.chars().enumerate() {
+            match character {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        // We're at the end.
+                        return Ok((&src[1..index], index));
+                    }
+                },
+                _ => {}
+            }
+        }
+
+        // Uh-oh, we got to the end and never closed the braces.
+        Err(ParseShaderError::UnmatchedBraces)
+    }
+}


### PR DESCRIPTION
closes #27 and #43

This PR replaces the existing system for building meshes from parsed COLLADA documents with a more robust system. Previously the system was heavily hard-coded to work with the handful of example meshes but did not adhere to the COLLADA standard. Now the processing (mostly) handles the data according to the standard and can more robustly handle a wider variety of COLLADA documents.

Other Changes
-------------------

I am trying out using [clog](https://github.com/clog-tool/clog-cli) to generate a changelog from the commit messages, and this PR adds the first version of that changelist.