### PR TITLE
Manage context handling for OpenGL rendering

### DIFF
--- a/lib/bootstrap-gl/src/lib.rs
+++ b/lib/bootstrap-gl/src/lib.rs
@@ -629,6 +629,8 @@ gl_proc!(glDeleteProgram:
     /// those shader objects will be automatically detached but not deleted unless they have
     /// already been flagged for deletion by a previous call to `delete_shader`.
     ///
+    /// A value of 0 (a "null" program object) for `program_object` will be silently ignored.
+    ///
     /// To determine whether a program object has been flagged for deletion call
     /// `get_program_param` with arguments `program_object` and `DeleteStatus`.
     fn delete_program(program_object: ProgramObject));

--- a/lib/gl-util/examples/hello_triangle.rs
+++ b/lib/gl-util/examples/hello_triangle.rs
@@ -12,10 +12,16 @@ static VERTEX_POSITIONS: [f32; 9] = [
 ];
 
 fn main() {
+    // Open a window to be used as a target for rendering.
     let mut window = Window::new("Hello, Triangle!");
 
+    // Create the OpenGL context. `Context::new()` will attempt to find a default render target,
+    // in this case it will use the window we just opened.
     let context = Context::new().unwrap();
-    let mut vertex_buffer = VertexBuffer::new();
+
+    // Create a vertex buffer to store the vertices of the triangle. We provide it with data and
+    // specify the layout of that data.
+    let mut vertex_buffer = VertexBuffer::new(&context);
     vertex_buffer.set_data_f32(&VERTEX_POSITIONS[..]);
     vertex_buffer.set_attrib_f32(
         "position",
@@ -25,7 +31,10 @@ fn main() {
             stride: 0,
         });
 
-    let mut draw_builder = DrawBuilder::new(&vertex_buffer, DrawMode::Triangles);
+    // `DrawBuilder` is used to specify all of the various configuration options when drawing. In
+    // this case we're using `vertex_buffer` in triangles mode, and we're sending its "position"
+    // attribute to attribute location 0, which is the default for `glPosition`.
+    let mut draw_builder = DrawBuilder::new(&context, &vertex_buffer, DrawMode::Triangles);
     draw_builder.map_attrib_location("position", AttributeLocation::from_index(0));
 
     'outer: loop {
@@ -36,6 +45,8 @@ fn main() {
             }
         }
 
+        // We use the context to clear the render target and swap buffers. `DrawBuilder` can be
+        // used multiple to avoid having to re-configure the build for each draw.
         context.clear();
         draw_builder.draw();
         context.swap_buffers();

--- a/lib/gl-util/examples/shader.rs
+++ b/lib/gl-util/examples/shader.rs
@@ -5,6 +5,7 @@ extern crate parse_obj;
 use bootstrap::window::*;
 use gl::*;
 use gl::context::Context;
+use gl::shader::*;
 use parse_obj::Obj;
 
 static VERT_SOURCE: &'static str = r#"
@@ -71,12 +72,12 @@ fn main() {
     let context = Context::new().unwrap();
 
     // Compile and link shaders into a shader program.
-    let vert_shader = Shader::new(VERT_SOURCE, ShaderType::Vertex).unwrap();
-    let frag_shader = Shader::new(FRAG_SOURCE, ShaderType::Fragment).unwrap();
-    let program = Program::new(&[vert_shader, frag_shader]).unwrap();
+    let vert_shader = Shader::new(&context, VERT_SOURCE, ShaderType::Vertex).unwrap();
+    let frag_shader = Shader::new(&context, FRAG_SOURCE, ShaderType::Fragment).unwrap();
+    let program = Program::new(&context, &[vert_shader, frag_shader]).unwrap();
 
     // Create the vertex buffer and set the vertex attribs.
-    let mut vertex_buffer = VertexBuffer::new();
+    let mut vertex_buffer = VertexBuffer::new(&context);
     vertex_buffer.set_data_f32(&*vertex_data);
     vertex_buffer.set_attrib_f32(
         "position",
@@ -94,10 +95,10 @@ fn main() {
         });
 
     // Create the index buffer.
-    let mut index_buffer = IndexBuffer::new();
+    let mut index_buffer = IndexBuffer::new(&context);
     index_buffer.set_data_u32(&*indices);
 
-    let mut draw_builder = DrawBuilder::new(&vertex_buffer, DrawMode::Triangles);
+    let mut draw_builder = DrawBuilder::new(&context, &vertex_buffer, DrawMode::Triangles);
     draw_builder
         .index_buffer(&index_buffer)
         .program(&program)

--- a/lib/gl-util/examples/texture.rs
+++ b/lib/gl-util/examples/texture.rs
@@ -5,6 +5,7 @@ extern crate parse_bmp;
 use bootstrap::window::*;
 use gl::*;
 use gl::context::Context;
+use gl::shader::*;
 use gl::texture::*;
 use parse_bmp::{
     Bitmap,
@@ -58,12 +59,12 @@ fn main() {
     let context = Context::new().unwrap();
 
     // Compile and link shaders into a shader program.
-    let vert_shader = Shader::new(VERT_SOURCE, ShaderType::Vertex).unwrap();
-    let frag_shader = Shader::new(FRAG_SOURCE, ShaderType::Fragment).unwrap();
-    let program = Program::new(&[vert_shader, frag_shader]).unwrap();
+    let vert_shader = Shader::new(&context, VERT_SOURCE, ShaderType::Vertex).unwrap();
+    let frag_shader = Shader::new(&context, FRAG_SOURCE, ShaderType::Fragment).unwrap();
+    let program = Program::new(&context, &[vert_shader, frag_shader]).unwrap();
 
     // Create the vertex buffer and set the vertex attribs.
-    let mut vertex_buffer = VertexBuffer::new();
+    let mut vertex_buffer = VertexBuffer::new(&context);
     vertex_buffer.set_data_f32(&VERTEX_DATA[..]);
     vertex_buffer.set_attrib_f32(
         "position",
@@ -88,6 +89,7 @@ fn main() {
     };
 
     let texture = Texture2d::new(
+        &context,
         TextureFormat::Bgr,
         TextureInternalFormat::Rgb,
         bitmap.width(),
@@ -95,7 +97,7 @@ fn main() {
         data)
         .unwrap();
 
-    let mut draw_builder = DrawBuilder::new(&vertex_buffer, DrawMode::Triangles);
+    let mut draw_builder = DrawBuilder::new(&context, &vertex_buffer, DrawMode::Triangles);
     draw_builder
         .program(&program)
         .map_attrib_name("position", "position")

--- a/lib/gl-util/examples/wireframe.rs
+++ b/lib/gl-util/examples/wireframe.rs
@@ -20,11 +20,11 @@ fn main() {
     let mut window = Window::new("gl-util - wireframe example");
     let context = Context::new().unwrap();
 
-    let mut vertex_buffer = VertexBuffer::new();
+    let mut vertex_buffer = VertexBuffer::new(&context);
     vertex_buffer.set_data_f32(obj.raw_positions());
     vertex_buffer.set_attrib_f32("position", AttribLayout { elements: 4, offset: 0, stride: 0 });
 
-    let mut index_buffer = IndexBuffer::new();
+    let mut index_buffer = IndexBuffer::new(&context);
     index_buffer.set_data_u32(&*raw_indices);
 
     'outer: loop {
@@ -36,7 +36,7 @@ fn main() {
         }
 
         context.clear();
-        DrawBuilder::new(&vertex_buffer, DrawMode::Triangles)
+        DrawBuilder::new(&context, &vertex_buffer, DrawMode::Triangles)
             .index_buffer(&index_buffer)
             .map_attrib_location("position", AttributeLocation::from_index(0))
             .polygon_mode(PolygonMode::Line)

--- a/lib/gl-util/src/context.rs
+++ b/lib/gl-util/src/context.rs
@@ -8,13 +8,11 @@ use gl::{
     StringName,
 };
 use std::ffi::CStr;
+use std::marker::PhantomData;
 use std::ptr;
 
 #[derive(Debug)]
-pub struct Context {
-    device_context: gl::DeviceContext,
-    render_context: gl::Context,
-}
+pub struct Context(gl::Context);
 
 impl Context {
     /// Creates a new rendering context.
@@ -65,47 +63,59 @@ impl Context {
                 gl::create_context(device_context)
                 .ok_or(Error::UnableToCreateRenderContext)?;
 
-            gl::enable(ServerCapability::DebugOutput);
-            gl::debug_message_callback(Some(debug_callback), ptr::null_mut());
+            {
+                let _guard = ::context::ContextGuard::new(&context);
 
-            let vendor = CStr::from_ptr(gl::get_string(StringName::Vendor)).to_str().unwrap();
-            let renderer = CStr::from_ptr(gl::get_string(StringName::Renderer)).to_str().unwrap();
-            let version = CStr::from_ptr(gl::get_string(StringName::Version)).to_str().unwrap();
-            let glsl_version = CStr::from_ptr(gl::get_string(StringName::ShadingLanguageVersion)).to_str().unwrap();
+                gl::enable(ServerCapability::DebugOutput);
+                gl::debug_message_callback(Some(debug_callback), ptr::null_mut());
 
-            println!("OpenGL Information:");
-            println!("\tvendor: {}", vendor);
-            println!("\trenderer: {}", renderer);
-            println!("\tversion: {}", version);
-            println!("\tglsl version: {}", glsl_version);
+                let vendor = CStr::from_ptr(gl::get_string(StringName::Vendor)).to_str().unwrap();
+                let renderer = CStr::from_ptr(gl::get_string(StringName::Renderer)).to_str().unwrap();
+                let version = CStr::from_ptr(gl::get_string(StringName::Version)).to_str().unwrap();
+                let glsl_version = CStr::from_ptr(gl::get_string(StringName::ShadingLanguageVersion)).to_str().unwrap();
 
-            // Load a bunch of proc pointers for funsies.
-            gl::get_attrib_location::load();
-            gl::gen_vertex_arrays::load();
+                println!("OpenGL Information:");
+                println!("\tvendor: {}", vendor);
+                println!("\trenderer: {}", renderer);
+                println!("\tversion: {}", version);
+                println!("\tglsl version: {}", glsl_version);
 
-            Ok(Context {
-                device_context: device_context,
-                render_context: context,
-            })
+                // Load a bunch of proc pointers for funsies.
+                gl::get_attrib_location::load();
+                gl::gen_vertex_arrays::load();
+            }
+
+            Ok(Context(context))
         }
     }
 
     /// TODO: Take clear mask (and values) as parameters.
     pub fn clear(&self) {
+        let _guard = ::context::ContextGuard::new(&self.0);
         unsafe { gl::clear(ClearBufferMask::Color | ClearBufferMask::Depth); }
     }
 
     pub fn swap_buffers(&self) {
-        unsafe { gl::platform::swap_buffers(self.device_context); }
+        let _guard = ::context::ContextGuard::new(&self.0);
+        unsafe { gl::platform::swap_buffers(self.0); }
+    }
+
+    /// Returns the underlying opengl context.
+    ///
+    /// This is used internally in conjunction with `ContextGuard` to ensure that any use of the
+    /// OpenGL api is correctly done with the correct context and that objects from different
+    /// contexts are not used together.
+    pub(crate) fn inner(&self) -> gl::Context {
+        self.0
     }
 }
 
 impl Drop for Context {
     fn drop(&mut self) {
         unsafe {
-            gl::make_current(self.device_context, self.render_context);
+            gl::make_current(self.0);
             gl::debug_message_callback(None, ptr::null_mut());
-            gl::destroy_context(self.render_context);
+            gl::destroy_context(self.0)
         }
     }
 }
@@ -122,4 +132,27 @@ pub enum Error {
     ///
     /// This might happen because reasons.
     UnableToCreateRenderContext,
+}
+
+#[derive(Debug)]
+pub(crate) struct ContextGuard<'a> {
+    old: gl::Context,
+    _phantom: PhantomData<&'a gl::Context>,
+}
+
+impl<'a> ContextGuard<'a> {
+    pub fn new(context: &gl::Context) -> ContextGuard {
+        let old = unsafe { gl::make_current(*context) };
+        ContextGuard {
+            old: old,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a> Drop for ContextGuard<'a> {
+    fn drop(&mut self) {
+        // TODO: Assert that the context is still current.
+        unsafe { gl::make_current(self.old); }
+    }
 }

--- a/lib/polygon_rs/src/lib.rs
+++ b/lib/polygon_rs/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(item_like_imports)]
 #![feature(question_mark)]
 
 extern crate parse_bmp;


### PR DESCRIPTION
Improve thread-safety when rendering with OpenGL by having gl-util track
each object's associated context and ensure that the context is made
current for the current thread whenver using an OpenGL API.