### PR TITLE
Add frame timing utilities

### DIFF
--- a/examples/empty.rs
+++ b/examples/empty.rs
@@ -1,11 +1,9 @@
 extern crate gunship;
 
-use gunship::*;
+use gunship::engine::EngineBuilder;
 
 fn main() {
-    // Create the engine.
-    EngineBuilder::new().build();
-
-    // Run the main loop.
-    Engine::start();
+    let mut builder = EngineBuilder::new();
+    builder.max_workers(1);
+    builder.build(|| {});
 }

--- a/lib/bootstrap-gl/examples/empty.rs
+++ b/lib/bootstrap-gl/examples/empty.rs
@@ -1,0 +1,75 @@
+extern crate bootstrap_rs as bootstrap;
+extern crate bootstrap_gl as gl;
+extern crate stopwatch;
+
+use bootstrap::window::*;
+use gl::*;
+use std::fs::File;
+use std::io::Write;
+use std::thread;
+use std::time::*;
+use stopwatch::*;
+
+fn main() {
+    let mut window = Window::new("OpenGL performance test").unwrap();
+
+    let mut times = Vec::with_capacity(10_000);
+
+    let device_context = window.platform().device_context();
+    let context = unsafe { gl::create_context(device_context).unwrap() };
+    unsafe { gl::make_current(context); }
+
+    let target_frame_time = Duration::new(0, 1_000_000_000 / 60);
+    let mut frame_start = Instant::now();
+    let start_time = frame_start;
+
+    'outer: loop {
+        {
+            let _s = Stopwatch::new("Loop");
+
+            {
+                let _s = Stopwatch::new("Window messages");
+                while let Some(message) = window.next_message() {
+                    if let Message::Close = message { break 'outer; }
+                }
+            }
+
+            {
+                let _s = Stopwatch::new("Clear buffer");
+                unsafe { gl::clear(ClearBufferMask::Color | ClearBufferMask::Depth); }
+            }
+
+            {
+                let _s = Stopwatch::new("Swap buffers");
+                unsafe { gl::platform::swap_buffers(context); }
+            }
+
+            times.push(frame_start.elapsed());
+        }
+
+        // Determine the next frame's start time, dropping frames if we missed the frame time.
+        while frame_start < Instant::now() {
+            frame_start += target_frame_time;
+        }
+
+        // Now wait until we've returned to the frame cadence before beginning the next frame.
+        while Instant::now() < frame_start {
+            thread::sleep(Duration::new(0, 0));
+        }
+    }
+
+    let run_duration = start_time.elapsed();
+    let stats = stats::analyze(&*times, target_frame_time);
+
+    println!("Performance statistics:");
+    println!("  Duration: {} ({} frames)", PrettyDuration(run_duration), times.len());
+    println!("  Min: {}", PrettyDuration(stats.min));
+    println!("  Max: {}", PrettyDuration(stats.max));
+    println!("  Mean: {}", PrettyDuration(stats.mean));
+    println!("  Std: {}", PrettyDuration(stats.std));
+    println!("  Long frames: {} ({:.2}%)", stats.long_frames, stats.long_frame_ratio * 100.0);
+
+    let events_string = stopwatch::write_events_to_string();
+    let mut out_file = File::create("bootstrap_gl_empty.json").unwrap();
+    out_file.write_all(events_string.as_bytes()).unwrap();
+}

--- a/lib/bootstrap-gl/src/lib.rs
+++ b/lib/bootstrap-gl/src/lib.rs
@@ -30,8 +30,8 @@ pub mod types;
 
 use std::mem;
 
-pub use self::types::*;
-pub use self::platform::*;
+pub use types::*;
+pub use platform::*;
 
 pub fn buffer_data<T>(target: BufferTarget, data: &[T], usage: BufferUsage) {
     unsafe {

--- a/lib/polygon_rs/examples/directional_light.rs
+++ b/lib/polygon_rs/examples/directional_light.rs
@@ -27,11 +27,13 @@ fn main() {
     anchor.set_position(Point::new(0.0, 0.0, 0.0));
     let mesh_anchor_id = renderer.register_anchor(anchor);
 
+    let mut material = renderer.default_material();
+    material.set_color("surface_color", Color::rgb(1.0, 0.0, 0.0));
+    material.set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
+    material.set_f32("surface_shininess", 4.0);
+
     // Create a mesh instance, attach it to the anchor, and register it with the renderer.
-    let mut mesh_instance = MeshInstance::new(gpu_mesh, renderer.default_material());
-    mesh_instance.material_mut().set_color("surface_color", Color::rgb(1.0, 0.0, 0.0));
-    mesh_instance.material_mut().set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
-    mesh_instance.material_mut().set_f32("surface_shininess", 4.0);
+    let mut mesh_instance = MeshInstance::with_owned_material(gpu_mesh, material);
     mesh_instance.set_anchor(mesh_anchor_id);
     renderer.register_mesh_instance(mesh_instance);
 

--- a/lib/polygon_rs/examples/hello_triangle.rs
+++ b/lib/polygon_rs/examples/hello_triangle.rs
@@ -36,10 +36,13 @@ fn main() {
     let anchor = Anchor::new();
     let anchor_id = renderer.register_anchor(anchor);
 
+    // Setup the material for the mesh.
+    let mut material = renderer.default_material();
+    material.set_color("surface_color", Color::rgb(1.0, 0.0, 0.0));
+
     // Create a mesh instance, attach it to the anchor, and register it.
-    let mut mesh_instance = MeshInstance::new(gpu_mesh, renderer.default_material());
+    let mut mesh_instance = MeshInstance::with_owned_material(gpu_mesh, material);
     mesh_instance.set_anchor(anchor_id);
-    mesh_instance.material_mut().set_color("surface_color", Color::rgb(1.0, 0.0, 0.0));
     renderer.register_mesh_instance(mesh_instance);
 
     // Create a camera and an anchor for it.

--- a/lib/polygon_rs/examples/materials.rs
+++ b/lib/polygon_rs/examples/materials.rs
@@ -41,36 +41,36 @@ fn main() {
     // Load the material for each of the meshes.
     let left_material_source =
         MaterialSource::from_file("resources/materials/diffuse_flat.material").unwrap();
-    let left_material = renderer.build_material(left_material_source).unwrap();
+    let mut left_material = renderer.build_material(left_material_source).unwrap();
+    left_material.set_color("surface_color", Color::rgb(1.0, 1.0, 0.0));
 
     let middle_material_source =
         MaterialSource::from_file("resources/materials/diffuse_lit.material").unwrap();
-    let middle_material = renderer.build_material(middle_material_source).unwrap();
+    let mut middle_material = renderer.build_material(middle_material_source).unwrap();
+    middle_material.set_color("surface_color", Color::rgb(0.0, 1.0, 1.0));
+    middle_material.set_color("specular_color", Color::rgb(1.0, 1.0, 1.0));
+    middle_material.set_f32("surface_shininess", 4.0);
 
     let right_material_source =
         MaterialSource::from_file("resources/materials/texture_diffuse_lit.material").unwrap();
-    let right_material = renderer.build_material(right_material_source).unwrap();
+    let mut right_material = renderer.build_material(right_material_source).unwrap();
+    right_material.set_texture("surface_diffuse", gpu_texture);
+    right_material.set_color("surface_color", Color::rgb(1.0, 1.0, 1.0));
+    right_material.set_color("specular_color", Color::rgb(0.2, 0.2, 0.2));
+    right_material.set_f32("surface_shininess", 3.0);
 
     // Create a mesh instance for each of the meshes, attach it to the anchor, and register it
     // with the renderer.
-    let mut left_mesh_instance = MeshInstance::new(gpu_mesh, left_material);
+    let mut left_mesh_instance = MeshInstance::with_owned_material(gpu_mesh, left_material);
     left_mesh_instance.set_anchor(left_anchor_id);
-    left_mesh_instance.material_mut().set_color("surface_color", Color::rgb(1.0, 1.0, 0.0));
     let left_instance_id = renderer.register_mesh_instance(left_mesh_instance);
 
-    let mut middle_mesh_instance = MeshInstance::new(gpu_mesh, middle_material);
+    let mut middle_mesh_instance = MeshInstance::with_owned_material(gpu_mesh, middle_material);
     middle_mesh_instance.set_anchor(middle_anchor_id);
-    middle_mesh_instance.material_mut().set_color("surface_color", Color::rgb(0.0, 1.0, 1.0));
-    middle_mesh_instance.material_mut().set_color("specular_color", Color::rgb(1.0, 1.0, 1.0));
-    middle_mesh_instance.material_mut().set_f32("surface_shininess", 4.0);
     renderer.register_mesh_instance(middle_mesh_instance);
 
-    let mut right_mesh_instance = MeshInstance::new(gpu_mesh, right_material);
+    let mut right_mesh_instance = MeshInstance::with_owned_material(gpu_mesh, right_material);
     right_mesh_instance.set_anchor(right_anchor_id);
-    right_mesh_instance.material_mut().set_texture("surface_diffuse", gpu_texture);
-    right_mesh_instance.material_mut().set_color("surface_color", Color::rgb(1.0, 1.0, 1.0));
-    right_mesh_instance.material_mut().set_color("specular_color", Color::rgb(0.2, 0.2, 0.2));
-    right_mesh_instance.material_mut().set_f32("surface_shininess", 3.0);
     renderer.register_mesh_instance(right_mesh_instance);
 
     // Create a camera and an anchor for it.
@@ -107,6 +107,7 @@ fn main() {
             let mesh_instance = renderer.get_mesh_instance_mut(left_instance_id).unwrap();
             mesh_instance
                 .material_mut()
+                .unwrap()
                 .set_color("surface_color", color);
         }
 

--- a/lib/polygon_rs/examples/multiple_lights.rs
+++ b/lib/polygon_rs/examples/multiple_lights.rs
@@ -36,13 +36,13 @@ fn main() {
     let mesh_anchor_id = renderer.register_anchor(anchor);
 
     let material_source = MaterialSource::from_file("resources/materials/diffuse_lit.material").unwrap();
-    let material = renderer.build_material(material_source).unwrap();
+    let mut material = renderer.build_material(material_source).unwrap();
+    material.set_color("surface_color", Color::rgb(1.0, 1.0, 1.0));
+    material.set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
+    material.set_f32("surface_shininess", 4.0);
 
     // Create a mesh instance, attach it to the anchor, and register it with the renderer.
-    let mut mesh_instance = MeshInstance::new(gpu_mesh, material);
-    mesh_instance.material_mut().set_color("surface_color", Color::rgb(1.0, 1.0, 1.0));
-    mesh_instance.material_mut().set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
-    mesh_instance.material_mut().set_f32("surface_shininess", 4.0);
+    let mut mesh_instance = MeshInstance::with_owned_material(gpu_mesh, material);
     mesh_instance.set_anchor(mesh_anchor_id);
     renderer.register_mesh_instance(mesh_instance);
 

--- a/lib/polygon_rs/examples/no_light.rs
+++ b/lib/polygon_rs/examples/no_light.rs
@@ -28,13 +28,13 @@ fn main() {
     let mesh_anchor_id = renderer.register_anchor(anchor);
 
     let material_source = MaterialSource::from_file("resources/materials/diffuse_lit.material").unwrap();
-    let material = renderer.build_material(material_source).unwrap();
+    let mut material = renderer.build_material(material_source).unwrap();
+    material.set_color("surface_color", Color::rgb(1.0, 1.0, 1.0));
+    material.set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
+    material.set_f32("surface_shininess", 4.0);
 
     // Create a mesh instance, attach it to the anchor, and register it with the renderer.
-    let mut mesh_instance = MeshInstance::new(gpu_mesh, material);
-    mesh_instance.material_mut().set_color("surface_color", Color::rgb(1.0, 1.0, 1.0));
-    mesh_instance.material_mut().set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
-    mesh_instance.material_mut().set_f32("surface_shininess", 4.0);
+    let mut mesh_instance = MeshInstance::with_owned_material(gpu_mesh, material);
     mesh_instance.set_anchor(mesh_anchor_id);
     renderer.register_mesh_instance(mesh_instance);
 

--- a/lib/polygon_rs/examples/point_light.rs
+++ b/lib/polygon_rs/examples/point_light.rs
@@ -29,13 +29,13 @@ fn main() {
     let mesh_anchor_id = renderer.register_anchor(anchor);
 
     let material_source = MaterialSource::from_file("resources/materials/diffuse_lit.material").unwrap();
-    let material = renderer.build_material(material_source).unwrap();
+    let mut material = renderer.build_material(material_source).unwrap();
+    material.set_color("surface_color", Color::rgb(1.0, 0.0, 1.0));
+    material.set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
+    material.set_f32("surface_shininess", 4.0);
 
     // Create a mesh instance, attach it to the anchor, and register it with the renderer.
-    let mut mesh_instance = MeshInstance::new(gpu_mesh, material);
-    mesh_instance.material_mut().set_color("surface_color", Color::rgb(1.0, 0.0, 1.0));
-    mesh_instance.material_mut().set_color("surface_specular", Color::rgb(1.0, 1.0, 1.0));
-    mesh_instance.material_mut().set_f32("surface_shininess", 4.0);
+    let mut mesh_instance = MeshInstance::with_owned_material(gpu_mesh, material);
     mesh_instance.set_anchor(mesh_anchor_id);
     renderer.register_mesh_instance(mesh_instance);
 

--- a/lib/polygon_rs/examples/textures.rs
+++ b/lib/polygon_rs/examples/textures.rs
@@ -40,9 +40,8 @@ fn main() {
     material.set_texture("surface_diffuse", gpu_texture);
 
     // Create a mesh instance, attach it to the anchor, and register it with the renderer.
-    let mut mesh_instance = MeshInstance::new(gpu_mesh, renderer.default_material());
+    let mut mesh_instance = MeshInstance::with_owned_material(gpu_mesh, material);
     mesh_instance.set_anchor(mesh_anchor_id);
-    mesh_instance.set_material(material);
     renderer.register_mesh_instance(mesh_instance);
 
     // Create a camera and an anchor for it.

--- a/lib/polygon_rs/src/gl/mod.rs
+++ b/lib/polygon_rs/src/gl/mod.rs
@@ -126,8 +126,6 @@ impl GlRender {
 
         let mesh_data = self.meshes.get(mesh_instance.mesh()).expect("Mesh data does not exist for mesh id");
 
-        let _stopwatch = Stopwatch::new("Drawing mesh");
-
         let default_texture = GlTexture2d::empty(&self.context);
 
         // Calculate the various transforms needed for rendering.

--- a/lib/polygon_rs/src/gl/mod.rs
+++ b/lib/polygon_rs/src/gl/mod.rs
@@ -58,7 +58,17 @@ pub struct GlRender {
 
 impl GlRender {
     pub fn new(window: &Window) -> Result<GlRender, Error> {
-        let context = Context::from_window(window)?;
+        let _s = Stopwatch::new("Initializing OpenGl renderer");
+
+        let context = {
+            let _s = Stopwatch::new("Creating context");
+            Context::from_window(window)?
+        };
+
+        {
+            let _s = Stopwatch::new("Clearing buffer");
+            context.clear();
+        }
 
         let mut renderer = GlRender {
             context: context,
@@ -340,6 +350,11 @@ impl Renderer for GlRender {
     fn draw(&mut self) {
         let _stopwatch = Stopwatch::new("GLRender::draw()");
 
+        {
+            let _stopwatch = Stopwatch::new("Clearing buffer");
+            self.context.clear();
+        }
+
         // TODO: Support rendering multiple cameras.
         // TODO: Should we warn if there are no cameras?
         if let Some(camera) = self.cameras.values().next() {
@@ -390,11 +405,6 @@ impl Renderer for GlRender {
         {
             let _stopwatch = Stopwatch::new("Swap buffers");
             self.context.swap_buffers();
-        }
-
-        {
-            let _stopwatch = Stopwatch::new("Clearing buffer");
-            self.context.clear();
         }
     }
 

--- a/lib/polygon_rs/src/lib.rs
+++ b/lib/polygon_rs/src/lib.rs
@@ -47,7 +47,7 @@ pub trait Renderer: 'static + Send {
     fn build_material(&mut self, source: MaterialSource) -> Result<Material, BuildMaterialError>;
 
     /// Registers a material to be used as a shared material.
-    fn register_material(&mut self, material: Material) -> MaterialId;
+    fn register_shared_material(&mut self, material: Material) -> MaterialId;
 
     /// Gets a registered material.
     fn get_material(&self, material_id: MaterialId) -> Option<&Material>;

--- a/lib/polygon_rs/src/material.rs
+++ b/lib/polygon_rs/src/material.rs
@@ -171,3 +171,9 @@ pub enum MaterialProperty {
     f32(f32),
     Vector3(Vector3),
 }
+
+#[derive(Debug, Clone)]
+pub enum MaterialType {
+    Shared(MaterialId),
+    Owned(Material),
+}

--- a/lib/polygon_rs/src/mesh_instance.rs
+++ b/lib/polygon_rs/src/mesh_instance.rs
@@ -9,26 +9,35 @@
 
 use {GpuMesh};
 use anchor::AnchorId;
-use material::Material;
+use material::*;
 
 /// Represents an instance of a mesh in the scene.
+///
+/// By default a mesh instance will not be attached to an anchor, and will not be rendered in
+/// the scene until one is set with `set_anchor()` and the mesh instance is registered with
+/// the renderer using `Renderer::register_mesh_instance()`.
 #[derive(Debug)]
 pub struct MeshInstance {
     mesh: GpuMesh,
-    material: Material,
+    material: MaterialType,
     anchor: Option<AnchorId>
 }
 
 impl MeshInstance {
-    /// Creates a new mesh instance for the specified mesh.
-    ///
-    /// By default a mesh instance will not be attached to an anchor, and will not be rendered in
-    /// the scene until one is set with `set_anchor()` and the mesh instance is registered with
-    /// the renderer using `Renderer::register_mesh_instance()`.
-    pub fn new(mesh: GpuMesh, material: Material) -> MeshInstance {
+    /// Creates a new mesh instance sharing the specified material.
+    pub fn with_shared_material(mesh: GpuMesh, material: MaterialId) -> MeshInstance {
         MeshInstance {
             mesh: mesh,
-            material: material,
+            material: MaterialType::Shared(material),
+            anchor: None,
+        }
+    }
+
+    /// Creates a new mesh instance with its own material.
+    pub fn with_owned_material(mesh: GpuMesh, material: Material) -> MeshInstance {
+        MeshInstance {
+            mesh: mesh,
+            material: MaterialType::Owned(material),
             anchor: None,
         }
     }
@@ -43,19 +52,33 @@ impl MeshInstance {
         &self.mesh
     }
 
-    /// Sets the material used by the mesh instance.
-    pub fn set_material(&mut self, material: Material) {
-        self.material = material;
-    }
-
-    /// Gets a reference to the material used by the mesh instance.
-    pub fn material(&self) -> &Material {
+    /// Gets a reference to either the shared material ID or the owned material.
+    pub fn material_type(&self) -> &MaterialType {
         &self.material
     }
 
-    /// Gets a mutable reference to the material used by the mesh instance.
-    pub fn material_mut(&mut self) -> &mut Material {
-        &mut self.material
+    /// Gets the shared material ID if the mesh instance is using a shared material.
+    pub fn shared_material(&self) -> Option<MaterialId> {
+        match self.material {
+            MaterialType::Shared(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    /// Gets a reference to the material used by the mesh instance if it owns its material.
+    pub fn material(&self) -> Option<&Material> {
+        match self.material {
+            MaterialType::Owned(ref material) => Some(material),
+            _ => None,
+        }
+    }
+
+    /// Gets a mutable reference to the material used by the mesh instance if it owns its material.
+    pub fn material_mut(&mut self) -> Option<&mut Material> {
+        match self.material {
+            MaterialType::Owned(ref mut material) => Some(material),
+            _ => None,
+        }
     }
 
     /// Attaches the mesh instance to the specified anchor.
@@ -64,8 +87,8 @@ impl MeshInstance {
     }
 
     /// Gets a reference to the anchor this instance is attached to.
-    pub fn anchor(&self) -> Option<&AnchorId> {
-        self.anchor.as_ref()
+    pub fn anchor(&self) -> Option<AnchorId> {
+        self.anchor
     }
 }
 

--- a/lib/stopwatch/src/stats.rs
+++ b/lib/stopwatch/src/stats.rs
@@ -1,0 +1,60 @@
+use std::time::Duration;
+
+// Calculate performance statistics.
+// ============================================================================================
+fn as_nanos(duration: Duration) -> u64 {
+    duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64
+}
+
+fn from_nanos(nanos: u64) -> Duration {
+    let secs = nanos / 1_000_000_000;
+    let subsec_nanos = nanos % 1_000_000_000;
+    Duration::new(secs, subsec_nanos as u32)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Statistics {
+    pub min: Duration,
+    pub max: Duration,
+    pub mean: Duration,
+    pub std: Duration,
+    pub long_frames: usize,
+    pub long_frame_ratio: f64,
+}
+
+pub fn analyze(frame_times: &[Duration], target_frame_time: Duration) -> Statistics {
+    let mut min = frame_times[0];
+    let mut max = frame_times[0];
+    let mut total = Duration::new(0, 0);
+    let mut long_frames = 0;
+
+    for time in frame_times.iter().cloned() {
+        total += time;
+        if time < min { min = time; }
+        if time > max { max = time; }
+        if time > target_frame_time { long_frames += 1; }
+    }
+
+    let mean = total / frame_times.len() as u32;
+    let total_sqr_deviation = frame_times.iter().cloned().fold(0, |total, time| {
+        let diff = if time < mean { mean - time } else { time - mean };
+
+        // Convert to nanos so that we can square and hope we don't overflow ¯\_(ツ)_/¯.
+        let nanos = as_nanos(diff);
+        let diff_sqr = nanos * nanos;
+
+        total + diff_sqr
+    });
+
+    let std_dev = from_nanos(f64::sqrt(total_sqr_deviation as f64 / frame_times.len() as f64) as u64);
+    let long_frame_ratio = long_frames as f64 / frame_times.len() as f64;
+
+    Statistics {
+        min: min,
+        max: max,
+        mean: mean,
+        std: std_dev,
+        long_frames: long_frames,
+        long_frame_ratio: long_frame_ratio,
+    }
+}


### PR DESCRIPTION
- Add more stopwatches to polygon and the engine in order to better capture timing.
- Track statistics about frame timing in the main loop and print analysis on shutdown. This is a temporary measure but it'll help identify when there are performance regressions or when I need to start working on optimizations.
- Add empty example for bootstrap-gl and update empty example for gunship.
- Add statistical analysis utilities to stopwatch for use in various places.